### PR TITLE
fix: Bare except: clauses swallowing exceptions

### DIFF
--- a/analytics_engine.py
+++ b/analytics_engine.py
@@ -367,7 +367,7 @@ class AppealProbabilityEstimator:
                     numbers = re.findall(r'\d+', cost_str)
                     if numbers:
                         costs.append(int(numbers[0]))
-                except:
+                except Exception:
                     pass
             
             if case.outcome_data.time_to_appeal_verdict:

--- a/pages/3_Report_Outcome.py
+++ b/pages/3_Report_Outcome.py
@@ -267,5 +267,5 @@ try:
         st.write(f"📤 Appeal feedback received from multiple users")
     else:
         st.info("Be the first to share your case outcome!")
-except:
+except Exception:
     st.info("Feedback statistics will appear here soon.")


### PR DESCRIPTION
Plan: Replace bare `except:` with `except Exception:` in the two files and verify changes — done.

- Completed: Replaced bare except in analytics_engine.py and 3_Report_Outcome.py.
- Verification: Searched the two files; no remaining bare `except:` occurrences found.

closes #62