### PR TITLE
Fix: Implement overlap guard for reminder job (#156)

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -156,6 +156,8 @@ def setup_scheduler(scheduler_class):
         name="Daily Deadline Reminder Check",
         replace_existing=True,
         misfire_grace_time=300,  # 5 minute grace for misfires
+        max_instances=1,
+        coalesce=True,
     )
     
     return scheduler


### PR DESCRIPTION
Added `max_instances=1` and `coalesce=True` to the reminder job configuration in `scheduler.py` to prevent overlapping executions and ensure missed runs are handled robustly.

- Closes #156
