### PR TITLE
fix: Type filter order is non-deterministic because it is built from …

### DIFF
--- a/pages/1_My_Cases.py
+++ b/pages/1_My_Cases.py
@@ -253,7 +253,7 @@ def main():
     with col2:
         type_filter = st.selectbox(
             "Filter by Type",
-            ["All"] + list(set(c["case_type"].title() for c in cases)),
+            ["All"] + sorted(set(c["case_type"].title() for c in cases)),
             key="type_filter",
         )
 

--- a/pages/3_Deadline_Tracker.py
+++ b/pages/3_Deadline_Tracker.py
@@ -190,7 +190,7 @@ def render_list_view(deadlines: List[Dict], user_id: int):
     with col2:
         type_filter = st.selectbox(
             "Type",
-            ["All"] + list(set(d["deadline_type"].title() for d in deadlines)),
+            ["All"] + sorted(set(d["deadline_type"].title() for d in deadlines)),
             key="deadline_type_filter",
         )
 


### PR DESCRIPTION


### **Changes Made**

1. **1_My_Cases.py** (Case Type Filter)
   - Before: `["All"] + list(set(c["case_type"].title() for c in cases))`
   - After: `["All"] + sorted(set(c["case_type"].title() for c in cases))`

2. **3_Deadline_Tracker.py** (Deadline Type Filter)
   - Before: `["All"] + list(set(d["deadline_type"].title() for d in deadlines))`
   - After: `["All"] + sorted(set(d["deadline_type"].title() for d in deadlines))`

### **Result**
✅ Filter dropdowns now display case and deadline types in consistent, alphabetical order
✅ Eliminates non-deterministic behavior caused by Python sets
✅ Improved user experience with predictable UI ordering
✅ No more instances of `list(set(...))` pattern in the codebase

closes #169