### PR TITLE
[HIGH] [Security] Fix Non-Atomic Redis Rate Limiter Operations Causing Persistent Keys

### DIFF
--- a/api/middleware.py
+++ b/api/middleware.py
@@ -13,21 +13,28 @@ logger = structlog.get_logger(__name__)
 
 class RateLimiter:
     """Token bucket rate limiter using Redis"""
-    
+
+    # Lua script: atomically increment the counter and set TTL on first write.
+    # Redis executes Lua scripts as a single atomic operation, so there is no
+    # window between INCR and EXPIRE where the key can be left without a TTL.
+    _INCR_EXPIRE_SCRIPT = """
+local current = redis.call('INCR', KEYS[1])
+if current == 1 then
+    redis.call('EXPIRE', KEYS[1], ARGV[1])
+end
+return current
+"""
+
     def __init__(self, redis_url: str = "redis://localhost:6379/0"):
         self.redis = redis.from_url(redis_url, decode_responses=True)
         self.requests = 100  # requests
         self.window = 60  # seconds
-    
+        self._script = self.redis.register_script(self._INCR_EXPIRE_SCRIPT)
+
     def is_allowed(self, key: str) -> bool:
         """Check if request is allowed"""
         try:
-            current = int(self.redis.incr(key))
-            
-            if current == 1:
-                # First request in this window
-                self.redis.expire(key, self.window)
-            
+            current = int(self._script(keys=[key], args=[self.window]))
             return current <= self.requests
         except Exception as e:
             logger.error("Rate limiter error", error=str(e))


### PR DESCRIPTION
📌 Description

This PR fixes a race condition in the Redis-based rate limiter caused by performing INCR and EXPIRE as separate operations inside RateLimiter.is_allowed.

Previously, if the application process crashed or terminated after the counter increment succeeded but before the expiration was applied, the Redis key could remain permanently without a TTL. This could result in stale rate-limit entries persisting indefinitely and users becoming permanently rate-limited.

The update improves reliability and consistency by ensuring rate-limit counter creation and expiration assignment occur atomically using a safer Redis operation pattern.

These changes strengthen the resilience of the rate-limiting mechanism under failure scenarios and prevent orphaned Redis keys from accumulating over time.

✨ Changes Included

Replaced non-atomic INCR + EXPIRE workflow with an atomic Redis operation pattern
Ensured rate-limit keys always receive a valid TTL upon creation
Prevented orphaned Redis counters caused by partial execution failures
Improved consistency and reliability of rate-limiter behavior under crashes or interruptions
Strengthened Redis key lifecycle management for rate-limit tracking

🧪 Testing Done

Verified rate-limit counters expire correctly after the configured window
Simulated failure scenarios between increment and expiration operations
Confirmed Redis keys no longer persist indefinitely without TTLs
Tested repeated requests to ensure rate-limiting behavior remains consistent
Checked for regressions in authenticated and anonymous rate-limit flows

closes #319 