### PR TITLE
Fix duplicate database query for regional trends metrics

### DIFF
--- a/app.py
+++ b/app.py
@@ -687,7 +687,9 @@ def main():
                                 with col1:
                                     st.metric("Total Cases Tracked", summary["total_cases_processed"])
                                 with col2:
-                                    st.metric("Appeals Success Rate", f"{AnalyticsAggregator.get_regional_trends(db)[0]['appeal_success_rate'] if AnalyticsAggregator.get_regional_trends(db) else 'N/A'}%")
+                                    regional_trends = AnalyticsAggregator.get_regional_trends(db)
+                                    appeal_rate = f"{regional_trends[0]['appeal_success_rate']}%" if regional_trends else 'N/A'
+                                    st.metric("Appeals Success Rate", appeal_rate)
                                 with col3:
                                     st.metric("Appeals Filed", summary["appeals_filed"])
                                 


### PR DESCRIPTION

### Problem
The `get_regional_trends(db)` method was called twice in the same expression, causing unnecessary database queries.

### Solution
Store the result in a variable and reuse it, reducing database calls from 2 to 1 per render.

### Changes
- Modified app.py line 690 to cache regional trends result
- Improved code readability and maintainability

### Impact
- 50% reduction in database queries for this metric
- Better performance and resource utilization

###Closes #132 