### PR TITLE
Fix: Add navigation button to Analytics Dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -691,7 +691,8 @@ def main():
                                 with col3:
                                     st.metric("Appeals Filed", summary["appeals_filed"])
                                 
-                                st.write("📌 **Visit Analytics Dashboard for detailed insights** ➡️ [See Full Dashboard]()")
+                                if st.button("📊 View Full Dashboard", use_container_width=True, key="full_dashboard"):
+                                    st.switch_page("pages/1_Analytics_Dashboard.py")
                             else:
                                 st.info("Analytics will be available as more cases are tracked.")
                         except Exception as e:


### PR DESCRIPTION
## Description
Fixes #133 - The "See Full Dashboard" link was empty and non-functional.

## Changes
- Replaced broken markdown link with a functional button in app.py (line 694)
- Button navigates to Analytics Dashboard using `st.switch_page()`

## Testing
- Quick Analytics Preview section now displays a working navigation button
- Clicking button successfully navigates to full Analytics Dashboard page