### PR TITLE
Fix issue #134: Trim whitespace from case number and jurisdiction

### DIFF
--- a/app.py
+++ b/app.py
@@ -246,10 +246,10 @@ def render_save_to_case_section(user_id, raw_text, summary, remedies):
     with col2:
         st.markdown("### New Case")
         with st.expander("➕ Create & Save New Case"):
-            new_case_number = st.text_input("Case Number", placeholder="e.g. CA/123/2024")
-            new_case_title = st.text_input("Case Title (Optional)", placeholder="e.g. Sharma vs State")
+            new_case_number = st.text_input("Case Number", placeholder="e.g. CA/123/2024").strip()
+            new_case_title = st.text_input("Case Title (Optional)", placeholder="e.g. Sharma vs State").strip()
             new_case_type = st.selectbox("Type", ["civil", "criminal", "family", "other"])
-            new_jurisdiction = st.text_input("Jurisdiction", placeholder="e.g. Delhi High Court")
+            new_jurisdiction = st.text_input("Jurisdiction", placeholder="e.g. Delhi High Court").strip()
             
             if st.button("Create Case & Save Document", use_container_width=True):
                 if new_case_number and new_jurisdiction:
@@ -618,10 +618,10 @@ def main():
                                 
                         with col2:
                             with st.expander("➕ Or Create New Case"):
-                                new_case_number = st.text_input("Case Number")
-                                new_case_title = st.text_input("Case Title (Optional)")
+                                new_case_number = st.text_input("Case Number").strip()
+                                new_case_title = st.text_input("Case Title (Optional)").strip()
                                 new_case_type = st.selectbox("Type", ["civil", "criminal", "family", "other"])
-                                new_jurisdiction = st.text_input("Jurisdiction", placeholder="e.g. Delhi High Court")
+                                new_jurisdiction = st.text_input("Jurisdiction", placeholder="e.g. Delhi High Court").strip()
                                 if st.button("Create & Save"):
                                     if new_case_number and new_jurisdiction:
                                         new_case = create_new_case(

--- a/case_manager.py
+++ b/case_manager.py
@@ -53,6 +53,13 @@ def create_new_case(
     """
     db = SessionLocal()
     try:
+        # Normalize inputs by trimming whitespace
+        case_number = case_number.strip()
+        jurisdiction = jurisdiction.strip()
+        case_type = case_type.strip()
+        if title:
+            title = title.strip()
+        
         # Check if case number already exists for this user
         existing = db.query(Case).filter(
             Case.user_id == user_id,


### PR DESCRIPTION
## Problem
Case number and jurisdiction inputs were not trimmed before save, allowing duplicates with different whitespace (e.g., "CA-123" vs "CA-123 ").

## Solution
- Added `.strip()` to normalize inputs in `create_new_case()` before duplicate check
- Added `.strip()` to form inputs in `app.py` (2 locations)

## Changes
- `case_manager.py`: Trim case_number, jurisdiction, case_type, and title
- `app.py`: Trim form inputs at point of capture (2 forms)

Fixes #134