### PR TITLE
[Issue #137] Add timeout to OpenAI API calls in cli.py

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -225,7 +225,11 @@ def _chat_completion(
     max_tokens: int,
     temperature: float,
     max_retries: int = 5,
+    timeout: float = None,
 ):
+    if timeout is None:
+        timeout = Config.LLM_TIMEOUT
+    
     last_err = None
     for attempt in range(max_retries):
         try:
@@ -238,6 +242,7 @@ def _chat_completion(
                     ],
                     max_tokens=max_tokens,
                     temperature=temperature,
+                    timeout=timeout,
                 )
         except RateLimitError as e:
             last_err = e


### PR DESCRIPTION
## Description
Fixes UI hanging indefinitely on slow network/API responses by adding timeout parameter to OpenAI API calls in cli.py.

## Changes
- Added `timeout` parameter to `_chat_completion()` function with default value from `Config.LLM_TIMEOUT` (60 seconds)
- Passes timeout to `client.chat.completions.create()` call
- Timeout value is configurable via `LLM_TIMEOUT` environment variable

## Related Issue
Fixes #137

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change