### PR TITLE
fix(#159): Use configurable BASE_URL for email notification links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,12 @@
 # --- App Identity ---
 APP_NAME="LegalEase AI"
 # Options: development, staging, production
+APP_ENV=development
+
+# --- Application URLs ---
+# Base URL for frontend links in emails and notifications (without trailing slash)
+BASE_URL=https://legalassist.ai
+
 # ==================== OpenAI / OpenRouter ====================
 OPENROUTER_API_KEY=your_openrouter_api_key_heresk-or-v1-a1d58e1bfb24e20786845ba35f6e96aacac998a5f3eb39c64c2a9f3afda8a31c
 OPENROUTER_BASE_URL=https://openrouter.ai/api/v1

--- a/config.py
+++ b/config.py
@@ -130,6 +130,9 @@ class Config:
         """Return the SendGrid API key, retrieved on demand to limit exposure."""
         return str(_get_val("SENDGRID_API_KEY", "") or "")
 
+    # --- Application URLs ---
+    BASE_URL = _get_val("BASE_URL", "https://legalassist.ai")
+
     @classmethod
     def is_development(cls):
         return cls.APP_ENV in ("dev", "development", "local") or cls.DEBUG or cls.TESTING

--- a/notification_service.py
+++ b/notification_service.py
@@ -158,6 +158,7 @@ class NotificationService:
     def __init__(self):
         self.sms_client = SMSClient()
         self.email_client = EmailClient()
+        self.base_url = Config.BASE_URL.rstrip('/')
 
     def build_sms_message(self, case_title: str, days_left: int, deadline_date: datetime) -> str:
         """Build SMS reminder message"""
@@ -247,7 +248,7 @@ class NotificationService:
                     </div>
 
                     <div style="text-align: center;">
-                        <a href="https://legalassist.ai/cases/{deadline.case_id}" class="cta-button">
+                        <a href="{self.base_url}/cases/{deadline.case_id}" class="cta-button">
                             View Case Dashboard
                         </a>
                     </div>
@@ -255,7 +256,7 @@ class NotificationService:
                 <div class="footer">
                     <p>This is an automated notification from your LegalAssist AI account.<br>
                     Missing deadlines can lead to dismissal of your case. Please consult with your legal counsel immediately.</p>
-                    <p>Manage your <a href="https://legalassist.ai/settings">Notification Preferences</a></p>
+                    <p>Manage your <a href="{self.base_url}/settings">Notification Preferences</a></p>
                 </div>
             </div>
         </body>


### PR DESCRIPTION
## Issue
Email templates hardcoded `https://legalassist.ai` domain which didn't work across different environments (staging, production, local development).

## Solution
- Added `BASE_URL` configuration in `config.py` (defaults to `https://legalassist.ai`)
- Updated `NotificationService` to use dynamic base URL from environment config
- Replaced hardcoded URLs in email template with dynamic URLs
- Documented new variable in `.env.example`

## Testing
- Local: `BASE_URL=http://localhost:8501`
- Staging: `BASE_URL=https://staging.legalassist.ai`
- Production: `BASE_URL=https://legalassist.ai` (default)

Fixes #159