### PR TITLE
[BUG] Celery tasks and HTTP requests do not propagate correlation IDs / tracing headers

### DIFF
--- a/api/routes/documents.py
+++ b/api/routes/documents.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, UploadFile, File, Form, HTTPException, status, De
 from fastapi import Request
 from api.models import DocumentAnalysisRequest, DocumentAnalysisSummary, AnalysisJobResponse
 from api.auth import get_current_user, CurrentUser
-from celery_app import analyze_document_task, TaskStatus
+from celery_app import analyze_document_task, TaskStatus, enqueue_task_from_http_request
 import structlog
 
 router = APIRouter(prefix="/api/v1/analyze", tags=["document-analysis"])
@@ -58,12 +58,14 @@ async def analyze_document(
     
     # Queue async task
     text = request.text or f"Content from {request.file_url or request.file_path}"
-    task = analyze_document_task.delay(
+    task = enqueue_task_from_http_request(
+        analyze_document_task,
+        http_request,
+        context_user_id=current_user.user_id,
         user_id=current_user.user_id,
         document_id=document_id,
         text=text,
         document_type=request.document_type,
-        request_id=getattr(http_request.state, "request_id", None),
     )
     
     return AnalysisJobResponse(

--- a/api/routes/reports.py
+++ b/api/routes/reports.py
@@ -5,14 +5,14 @@ GET /api/v1/reports/{report_id} - Get report status
 GET /api/v1/reports/{report_id}/download - Download report
 """
 import uuid
-from fastapi import APIRouter, HTTPException, status, Depends
+from fastapi import APIRouter, HTTPException, status, Depends, Request
 from fastapi.responses import FileResponse
 from pathlib import Path
 from report_service import _get_reports_base_dir
 
 from api.models import ReportGenerationRequest, ReportGenerationResponse
 from api.auth import get_current_user, CurrentUser
-from celery_app import generate_report_task, TaskStatus
+from celery_app import generate_report_task, TaskStatus, enqueue_task_from_http_request
 import structlog
 from datetime import datetime
 
@@ -27,6 +27,7 @@ logger = structlog.get_logger(__name__)
 )
 async def generate_report(
     request: ReportGenerationRequest,
+    http_request: Request,
     current_user: CurrentUser = Depends(get_current_user)
 ) -> ReportGenerationResponse:
     """
@@ -51,7 +52,10 @@ async def generate_report(
     )
     
     # Queue async task
-    task = generate_report_task.delay(
+    task = enqueue_task_from_http_request(
+        generate_report_task,
+        http_request,
+        context_user_id=current_user.user_id,
         user_id=current_user.user_id,
         case_id=request.case_id,
         report_type=request.report_type,

--- a/celery_app.py
+++ b/celery_app.py
@@ -28,7 +28,13 @@ from celery.result import AsyncResult
 # Import project settings for fallback and other configurations
 from api.config import get_settings
 from observability.integration import initialize_observability_for_environment
-from observability.instrumentation import traced_operation, capture_exception, bind_request_context, clear_request_context
+from observability.instrumentation import (
+    traced_operation,
+    capture_exception,
+    bind_request_context,
+    clear_request_context,
+    generate_correlation_id,
+)
 
 # ============================================================================
 # INITIALIZATION & LOGGING
@@ -40,6 +46,48 @@ settings = get_settings()
 # Initialize the structured logger for consistent logging across tasks
 logger = structlog.get_logger(__name__)
 initialize_observability_for_environment()
+
+
+def build_task_context_headers(
+    request_id: Optional[str] = None,
+    context_user_id: Optional[str] = None,
+) -> Dict[str, str]:
+    """Build Celery task headers used to propagate request context."""
+    resolved_request_id = request_id or generate_correlation_id()
+    headers = {
+        "x-request-id": resolved_request_id,
+        "x-correlation-id": resolved_request_id,
+    }
+    if context_user_id:
+        headers["x-user-id"] = str(context_user_id)
+    return headers
+
+
+def enqueue_task_with_context(task, *, request_id: Optional[str] = None, context_user_id: Optional[str] = None, **task_kwargs):
+    """Enqueue a Celery task with request context propagated in headers."""
+    headers = build_task_context_headers(request_id=request_id, context_user_id=context_user_id)
+    return task.apply_async(kwargs=task_kwargs, headers=headers)
+
+
+def enqueue_task_from_http_request(task, http_request, *, context_user_id: Optional[str] = None, **task_kwargs):
+    """Enqueue task carrying context from a FastAPI request object."""
+    request_id = getattr(http_request.state, "request_id", None) or getattr(http_request.state, "correlation_id", None)
+    if not request_id:
+        request_id = (
+            http_request.headers.get("X-Request-Id")
+            or http_request.headers.get("X-Correlation-Id")
+            or http_request.headers.get("x-request-id")
+            or http_request.headers.get("x-correlation-id")
+        )
+
+    user_id = context_user_id or getattr(http_request.state, "user_id", None) or http_request.headers.get("X-User-Id")
+
+    return enqueue_task_with_context(
+        task,
+        request_id=request_id,
+        context_user_id=user_id,
+        **task_kwargs,
+    )
 
 
 # ============================================================================
@@ -60,6 +108,28 @@ class ContextTask(Task):
     autoretry_for = (Exception,)
     retry_kwargs = {'max_retries': 3}
     retry_backoff = True
+
+    @staticmethod
+    def _extract_task_request_context(task_request) -> Dict[str, Optional[str]]:
+        headers = getattr(task_request, "headers", None) or {}
+        request_id = (
+            headers.get("x-request-id")
+            or headers.get("X-Request-Id")
+            or headers.get("x-correlation-id")
+            or headers.get("X-Correlation-Id")
+            or getattr(task_request, "root_id", None)
+            or getattr(task_request, "id", None)
+        )
+        user_id = headers.get("x-user-id") or headers.get("X-User-Id")
+        return {"request_id": request_id, "user_id": user_id}
+
+    def __call__(self, *args, **kwargs):
+        context = self._extract_task_request_context(self.request)
+        bind_request_context(request_id=context.get("request_id"), user_id=context.get("user_id"))
+        try:
+            return self.run(*args, **kwargs)
+        finally:
+            clear_request_context()
 
 
 # ============================================================================

--- a/observability/instrumentation.py
+++ b/observability/instrumentation.py
@@ -250,6 +250,7 @@ def setup_structured_logging():
     """Configure structlog for JSON-formatted logging with correlation IDs"""
     structlog.configure(
         processors=[
+            structlog.contextvars.merge_contextvars,
             structlog.stdlib.filter_by_level,
             structlog.stdlib.add_logger_name,
             structlog.stdlib.add_log_level,
@@ -332,10 +333,13 @@ def bind_request_context(*, request_id: str | None = None, user_id: str | None =
     """Bind request-scoped context for logs and traces."""
     if request_id is not None:
         _REQUEST_ID.set(request_id)
+        structlog.contextvars.bind_contextvars(request_id=request_id)
     if user_id is not None:
         _USER_ID.set(user_id)
+        structlog.contextvars.bind_contextvars(user_id=user_id)
     if session_id is not None:
         _SESSION_ID.set(session_id)
+        structlog.contextvars.bind_contextvars(session_id=session_id)
 
 
 def get_request_context() -> dict:
@@ -347,7 +351,10 @@ def get_request_context() -> dict:
 
 
 def clear_request_context():
-    bind_request_context(request_id=None, user_id=None, session_id=None)
+    _REQUEST_ID.set(None)
+    _USER_ID.set(None)
+    _SESSION_ID.set(None)
+    structlog.contextvars.clear_contextvars()
 
 
 def record_api_error(endpoint: str, error: Exception | str):

--- a/tests/test_correlation_propagation.py
+++ b/tests/test_correlation_propagation.py
@@ -1,0 +1,62 @@
+from types import SimpleNamespace
+
+from celery_app import (
+    ContextTask,
+    build_task_context_headers,
+    enqueue_task_from_http_request,
+)
+
+
+def test_build_task_context_headers_uses_request_id_and_user_id():
+    headers = build_task_context_headers(request_id="req-123", context_user_id="user-7")
+
+    assert headers["x-request-id"] == "req-123"
+    assert headers["x-correlation-id"] == "req-123"
+    assert headers["x-user-id"] == "user-7"
+
+
+def test_context_task_extracts_request_context_from_headers():
+    task_request = SimpleNamespace(
+        headers={
+            "x-request-id": "req-abc",
+            "x-user-id": "user-xyz",
+        },
+        root_id="root-fallback",
+        id="task-fallback",
+    )
+
+    context = ContextTask._extract_task_request_context(task_request)
+
+    assert context["request_id"] == "req-abc"
+    assert context["user_id"] == "user-xyz"
+
+
+def test_enqueue_task_from_http_request_passes_headers_to_apply_async():
+    captured = {}
+
+    class FakeTask:
+        def apply_async(self, kwargs, headers):
+            captured["kwargs"] = kwargs
+            captured["headers"] = headers
+            return SimpleNamespace(id="task-1")
+
+    http_request = SimpleNamespace(
+        state=SimpleNamespace(request_id="req-777", user_id="user-state"),
+        headers={"X-Correlation-Id": "req-from-header", "X-User-Id": "user-header"},
+    )
+
+    result = enqueue_task_from_http_request(
+        FakeTask(),
+        http_request,
+        context_user_id="user-999",
+        user_id="task-user",
+        document_id="doc-1",
+        text="hello",
+    )
+
+    assert result.id == "task-1"
+    assert captured["kwargs"]["user_id"] == "task-user"
+    assert captured["kwargs"]["document_id"] == "doc-1"
+    assert captured["headers"]["x-request-id"] == "req-777"
+    assert captured["headers"]["x-correlation-id"] == "req-777"
+    assert captured["headers"]["x-user-id"] == "user-999"


### PR DESCRIPTION
## Summary
This PR fixes missing correlation ID propagation between FastAPI requests and Celery workers.

Before this change, request logs and worker logs were disconnected, making it hard to trace a single operation end-to-end.

After this change:
- API request context (`request_id` / `correlation_id` / `user_id`) is added to Celery task headers.
- Celery workers read these headers and bind them into logging context during task execution.
- Structured logs now include contextvars, so request/task logs can be correlated reliably.

## What I Changed

### 1) Celery context propagation helpers
File: `celery_app.py`

Added:
- `build_task_context_headers(...)`
- `enqueue_task_with_context(...)`
- `enqueue_task_from_http_request(...)`

These helpers standardize how task headers are created and sent with `apply_async(...)`.

### 2) Worker-side context binding
File: `celery_app.py`

Enhanced `ContextTask`:
- Added `_extract_task_request_context(...)` to read request headers from Celery task request metadata.
- Overrode `__call__(...)` to bind context before task execution and clear it after execution.

### 3) API routes now enqueue tasks with request context
Files:
- `api/routes/documents.py`
- `api/routes/reports.py`

Replaced direct `.delay(...)` calls with `enqueue_task_from_http_request(...)` so task headers carry request correlation context.

### 4) Structured logging context support
File: `observability/instrumentation.py`

Updates:
- Added `structlog.contextvars.merge_contextvars` in structlog processors.
- `bind_request_context(...)` now binds to structlog contextvars too.
- `clear_request_context()` now properly clears all request-scoped vars.

### 5) Tests added
File: `tests/test_correlation_propagation.py`

Added tests to verify:
- context headers are built correctly
- worker context extraction from task headers works
- API enqueue helper forwards headers to `apply_async(...)`

## Why this is important
This gives us end-to-end traceability across:
- HTTP request logs
- async Celery worker logs

It improves debugging, incident response, and observability for async workflows.

## Validation
Executed:
- `pytest tests/test_correlation_propagation.py -q`

Result:
- 3 passed, 0 failed

Also checked edited files for diagnostics:
- No static errors reported.

## ISSUE RESOLVED #411 