### PR TITLE
Make TrustedHostMiddleware allowed hosts configurable via environment variable

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -26,6 +26,11 @@ class APISettings(BaseSettings):
         "http://localhost:8000",
     ]
     
+    # Allowed Hosts for TrustedHostMiddleware
+    # Format: comma-separated (localhost,127.0.0.1,example.com) or JSON array
+    # Default: localhost, 127.0.0.1
+    ALLOWED_HOSTS: list = None
+    
     # Rate Limiting
     RATE_LIMIT_ENABLED: bool = True
     RATE_LIMIT_REQUESTS: int = 100  # requests
@@ -90,6 +95,25 @@ class APISettings(BaseSettings):
     ENABLE_OAUTH2: bool = os.getenv("ENABLE_OAUTH2", "true").lower() == "true"
     ENABLE_WEBSOCKET: bool = os.getenv("ENABLE_WEBSOCKET", "true").lower() == "true"
     ENABLE_ANALYTICS: bool = os.getenv("ENABLE_ANALYTICS", "true").lower() == "true"
+    
+    def __init__(self, **data):
+        super().__init__(**data)
+        # Parse ALLOWED_HOSTS from environment
+        if self.ALLOWED_HOSTS is None:
+            hosts_env = os.getenv("APP_ALLOWED_HOSTS", "")
+            if hosts_env.strip():
+                # Support both comma-separated and JSON formats
+                if hosts_env.startswith('['):
+                    import json
+                    try:
+                        self.ALLOWED_HOSTS = json.loads(hosts_env)
+                    except (json.JSONDecodeError, ValueError):
+                        self.ALLOWED_HOSTS = [h.strip() for h in hosts_env.split(',') if h.strip()]
+                else:
+                    self.ALLOWED_HOSTS = [h.strip() for h in hosts_env.split(',') if h.strip()]
+            else:
+                # Safe defaults for development
+                self.ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
     
     class Config:
         env_file = ".env"

--- a/api/main.py
+++ b/api/main.py
@@ -48,7 +48,7 @@ middleware = [
     ),
     Middleware(
         TrustedHostMiddleware,
-        allowed_hosts=["localhost", "127.0.0.1", "*.example.com"]
+        allowed_hosts=settings.ALLOWED_HOSTS
     ),
 ]
 

--- a/docker-compose-api.yml
+++ b/docker-compose-api.yml
@@ -26,6 +26,7 @@ services:
       - API_KEY_ENABLED=true
       - ENABLE_WEBSOCKET=true
       - CORS_ORIGINS=["http://localhost:3000", "http://localhost:8501", "http://localhost:8000"]
+      - APP_ALLOWED_HOSTS=localhost,127.0.0.1,0.0.0.0
     depends_on:
       - postgres
       - redis


### PR DESCRIPTION

## Changes
- Add `ALLOWED_HOSTS` configuration to APISettings
- Parse `APP_ALLOWED_HOSTS` environment variable (supports comma-separated or JSON formats)
- Use safe development defaults: `["localhost", "127.0.0.1"]`
- Update TrustedHostMiddleware to use environment-driven hosts
- Add example in docker-compose-api.yml

## Usage
```bash
# Development (automatic)
# No env var needed → uses ["localhost", "127.0.0.1"]

# Production
export APP_ALLOWED_HOSTS=api.example.com,*.api.example.com
```

### Closes #432 