### PR TITLE
Cross-platform upload temp directory support (Issue #433)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -2,6 +2,8 @@
 API Configuration
 """
 import os
+import tempfile
+from pathlib import Path
 from typing import Optional
 from pydantic_settings import BaseSettings
 
@@ -65,7 +67,10 @@ class APISettings(BaseSettings):
     # File Upload
     UPLOAD_MAX_SIZE: int = 500 * 1024 * 1024  # 500 MB
     UPLOAD_EXTENSIONS: list = [".pdf", ".doc", ".docx", ".txt", ".html"]
-    UPLOAD_TEMP_DIR: str = "/tmp/legalassist-uploads"
+    UPLOAD_TEMP_DIR: str = os.getenv(
+        "UPLOAD_TEMP_DIR",
+        str(Path(tempfile.gettempdir()) / "legalassist-uploads")
+    )
     
     # PDF Export
     PDF_MAX_PAGES: int = 5000


### PR DESCRIPTION
## Description
Replaces hardcoded Unix path `/tmp/legalassist-uploads` with cross-platform support using `tempfile.gettempdir()`.

## Changes
- Updated `UPLOAD_TEMP_DIR` to automatically resolve to system temp directory
- Windows: `C:\Users\{user}\AppData\Local\Temp\legalassist-uploads`
- Linux/Mac: `/tmp/legalassist-uploads`
- Supports environment variable override via `UPLOAD_TEMP_DIR` env var

## Fixes
Resolves #433

## Type of Change
- [x] Bug fix