### PR TITLE
Fix Helm Chart placeholder URLs and maintainer info

### DIFF
--- a/k8s/helm/legalassist-ai/Chart.yaml
+++ b/k8s/helm/legalassist-ai/Chart.yaml
@@ -5,9 +5,9 @@ type: application
 version: 1.0.0
 appVersion: "1.0.0"
 
-home: https://github.com/yourusername/legalassist-ai
+home: https://github.com/AseemPrasad/legalassist-ai
 sources:
-  - https://github.com/yourusername/legalassist-ai
+  - https://github.com/AseemPrasad/legalassist-ai
 keywords:
   - legal
   - ai
@@ -16,5 +16,5 @@ keywords:
   - case-management
 
 maintainers:
-  - name: Your Name
-    email: your-email@example.com
+  - name: Aseem Prasad
+    email: contact@legalassist.dev

--- a/k8s/helm/legalassist-ai/values-production.yaml
+++ b/k8s/helm/legalassist-ai/values-production.yaml
@@ -2,7 +2,7 @@
 replicaCount: 3
 
 image:
-  repository: ghcr.io/yourusername/legalassist-ai
+  repository: ghcr.io/AseemPrasad/legalassist-ai
   tag: latest
   pullPolicy: IfNotPresent
 
@@ -29,14 +29,14 @@ ingress:
     nginx.ingress.kubernetes.io/rate-limit: "100"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
   hosts:
-    - host: legalassist.example.com
+    - host: REPLACE_ME_WITH_YOUR_PRODUCTION_DOMAIN
       paths:
         - path: /
           pathType: Prefix
   tls:
     - secretName: legalassist-tls
       hosts:
-        - legalassist.example.com
+        - REPLACE_ME_WITH_YOUR_PRODUCTION_DOMAIN
 
 postgresql:
   auth:

--- a/k8s/helm/legalassist-ai/values-staging.yaml
+++ b/k8s/helm/legalassist-ai/values-staging.yaml
@@ -2,7 +2,7 @@
 replicaCount: 2
 
 image:
-  repository: ghcr.io/yourusername/legalassist-ai
+  repository: ghcr.io/AseemPrasad/legalassist-ai
   tag: staging
   pullPolicy: Always
 
@@ -23,14 +23,14 @@ autoscaling:
 ingress:
   enabled: true
   hosts:
-    - host: staging.legalassist.example.com
+    - host: REPLACE_ME_WITH_YOUR_STAGING_DOMAIN
       paths:
         - path: /
           pathType: Prefix
   tls:
     - secretName: staging-tls
       hosts:
-        - staging.legalassist.example.com
+        - REPLACE_ME_WITH_YOUR_STAGING_DOMAIN
 
 postgresql:
   auth:

--- a/k8s/helm/legalassist-ai/values.yaml
+++ b/k8s/helm/legalassist-ai/values.yaml
@@ -3,7 +3,7 @@
 replicaCount: 3
 
 image:
-  repository: legalassist-ai
+  repository: ghcr.io/AseemPrasad/legalassist-ai
   tag: latest
   pullPolicy: IfNotPresent
 
@@ -45,14 +45,14 @@ ingress:
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
   hosts:
-    - host: legalassist.example.com
+    - host: REPLACE_ME_WITH_YOUR_DOMAIN
       paths:
         - path: /
           pathType: Prefix
   tls:
     - secretName: legalassist-tls
       hosts:
-        - legalassist.example.com
+        - REPLACE_ME_WITH_YOUR_DOMAIN
 
 resources:
   limits:


### PR DESCRIPTION
## Description
Fixes misleading placeholder URLs in Helm charts that confuse new users.

## Changes
- Replace `yourusername` with official org `AseemPrasad` across all chart files
- Update maintainer name and email to actual contact details
- Replace bare image repo with full registry path: `ghcr.io/AseemPrasad/legalassist-ai`
- Replace `example.com` domains with explicit `REPLACE_ME_WITH_YOUR_*` placeholders

## Files Changed
- Chart.yaml
- values.yaml
- values-production.yaml
- values-staging.yaml

Closes #436