### PR TITLE
Optimize WebSocket endpoint imports to resolve performance bottleneck

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -9,6 +9,7 @@ from fastapi.responses import JSONResponse, Response
 from fastapi.openapi.utils import get_openapi
 from fastapi import status
 import structlog
+import asyncio
 
 from api.config import get_settings
 from api.middleware import (
@@ -255,6 +256,7 @@ app = create_app()
 
 if settings.ENABLE_WEBSOCKET:
     from fastapi import WebSocket
+    from celery_app import TaskStatus
     
     @app.websocket("/ws/progress/{job_id}")
     async def websocket_progress_endpoint(websocket: WebSocket, job_id: str):
@@ -268,11 +270,7 @@ if settings.ENABLE_WEBSOCKET:
         await websocket.accept()
         
         try:
-            from celery_app import TaskStatus
-            
             while True:
-                import asyncio
-                
                 status_info = TaskStatus.get_task_status(job_id)
                 
                 await websocket.send_json({


### PR DESCRIPTION
This PR resolves issue #452 by moving `asyncio` and `TaskStatus` imports out of the `while True` loop and the `websocket_progress_endpoint` function body. 

**Key Changes:**
- Relocated `import asyncio` to the global scope (adhering to PEP 8).
- Moved `from celery_app import TaskStatus` to the `if settings.ENABLE_WEBSOCKET:` block to ensure it's only loaded once when the application starts.
- Removed redundant imports from the progress-tracking loop to eliminate unnecessary module lookups every 2 seconds.



### Closes #452
