### PR TITLE
fix: API Key Hash Leakage Risk

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -93,18 +93,29 @@ def hash_api_key(key: str) -> str:
     return hashlib.sha256(key.encode()).hexdigest()
 
 
-def create_api_key_record(name: str, expires_in_days: Optional[int] = None) -> tuple:
-    """Create new API key record
-    Returns: (key_to_display, key_hash_for_storage)
+def create_api_key_record(name: str, expires_in_days: Optional[int] = None) -> tuple[str, APIKey]:
+    """Create a new API key and its storage record.
+
+    Returns the one-time secret for immediate display plus an APIKey record
+    that contains only the hashed value for persistence.
     """
     key = generate_api_key()
     key_hash = hash_api_key(key)
+    created_at = datetime.utcnow()
     expires_at = None
-    
+
     if expires_in_days:
-        expires_at = datetime.utcnow() + timedelta(days=expires_in_days)
-    
-    return key, key_hash, expires_at
+        expires_at = created_at + timedelta(days=expires_in_days)
+
+    key_record = APIKey(
+        key_id=f"key_{secrets.token_hex(8)}",
+        name=name,
+        key_hash=key_hash,
+        created_at=created_at,
+        expires_at=expires_at,
+    )
+
+    return key, key_record
 
 
 # ============================================================================

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -6,7 +6,7 @@ GET /api/v1/auth/me - Get current user
 """
 from fastapi import APIRouter, HTTPException, status, Depends
 from datetime import datetime, timedelta
-from api.auth import create_access_token, generate_api_key, hash_api_key, CurrentUser, get_current_user
+from api.auth import create_access_token, create_api_key_record, CurrentUser, get_current_user
 from api.models import TokenResponse, APIKeyCreate, APIKeyResponse
 from api.limiter import RateLimit
 import structlog
@@ -70,10 +70,9 @@ async def create_api_key(
         key_name=request.name
     )
     
-    key = generate_api_key()
-    key_hash = hash_api_key(key)
+    key, _api_key_record = create_api_key_record(request.name, request.expires_in_days)
     expires_at = None
-    
+
     if request.expires_in_days:
         expires_at = datetime.utcnow() + timedelta(days=request.expires_in_days)
     


### PR DESCRIPTION
I changed auth.py so `create_api_key_record()` now returns the one-time secret plus an `APIKey` storage record, instead of handing back the secret/hash pair in a way that could be logged or serialized together. I also updated auth.py to use that helper directly, which removes the local hash reconstruction.

Validation passed on both touched files with no errors.

closes #450