### PR TITLE
[REFACTOR] Extract “reminder decision logic” from scheduler.check_and_send_reminder

### DIFF
--- a/database.py
+++ b/database.py
@@ -31,182 +31,51 @@ try:
     import redis
 except ImportError:  # pragma: no cover - handled at runtime if Redis is unavailable
     redis = None
+"""Thin compatibility shim. Re-exports core database symbols from the new db package.
 
-# Database setup
-DATABASE_URL = Config.DATABASE_URL
-_db_url = make_url(DATABASE_URL)
-_is_sqlite = _db_url.get_backend_name() == "sqlite"
-engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False} if _is_sqlite else {})
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, expire_on_commit=False, bind=engine)
-Base = declarative_base()
-
-logger = logging.getLogger(__name__)
-auth_logger = logging.getLogger("auth.otp")
-
-_OTP_RATE_LIMIT_WINDOW_SECONDS = 60 * 60
-_OTP_RATE_LIMIT_SCRIPT = """
-local current = redis.call('INCR', KEYS[1])
-if current == 1 then
-    redis.call('EXPIRE', KEYS[1], ARGV[1])
-end
-return current
+This file keeps existing imports in the codebase working while models and CRUD
+helpers are moved into `db/` package.
 """
-_otp_rate_limit_client = None
-_otp_rate_limit_script = None
 
+from db.session import engine, SessionLocal, init_db, db_session, get_db, _to_utc_datetime, _datetime_for_db
+from db.models.notifications import NotificationStatus, NotificationChannel, NotificationLog, NotificationTemplate, UserPreference
+from db.models.cases import CaseDeadline, Case, CaseDocument, Attachment, CaseTimeline
+from db.models.auth import User, OTPVerification
+from db.crud.notifications import (
+    create_case_deadline,
+    get_upcoming_deadlines,
+    has_notification_been_sent,
+    log_notification,
+    get_notification_history,
+)
 
-def _to_utc_datetime(value: dt.datetime) -> dt.datetime:
-    """Convert a datetime to timezone-aware UTC."""
-    if value.tzinfo is None:
-        return value.replace(tzinfo=dt.timezone.utc)
-    return value.astimezone(dt.timezone.utc)
+__all__ = [
+    "engine",
+    "SessionLocal",
+    "init_db",
+    "db_session",
+    "get_db",
+    "_to_utc_datetime",
+    "_datetime_for_db",
+    "NotificationStatus",
+    "NotificationChannel",
+    "UserPreference",
+    "NotificationLog",
+    "NotificationTemplate",
+    "CaseDeadline",
+    "Case",
+    "CaseDocument",
+    "Attachment",
+    "CaseTimeline",
+    "User",
+    "OTPVerification",
+    "create_case_deadline",
+    "get_upcoming_deadlines",
+    "has_notification_been_sent",
+    "log_notification",
+    "get_notification_history",
+]
 
-
-def _datetime_for_db(value: dt.datetime) -> dt.datetime:
-    """Return a datetime in the format best suited for the current backend."""
-    utc_value = _to_utc_datetime(value)
-    if _is_sqlite:
-        return utc_value.replace(tzinfo=None)
-    return utc_value
-
-
-class NotificationStatus(str, enum.Enum):
-    """Status of sent notifications"""
-    PENDING = "pending"
-    SENT = "sent"
-    FAILED = "failed"
-    BOUNCED = "bounced"
-    OPENED = "opened"
-
-
-class NotificationChannel(str, enum.Enum):
-    """Channel for sending notifications"""
-    SMS = "sms"
-    EMAIL = "email"
-    BOTH = "both"
-
-
-class CaseDeadline(Base):
-    """Model for case deadlines"""
-    __tablename__ = "case_deadlines"
-
-    id = Column(Integer, primary_key=True)
-    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False)
-    case_id = Column(Integer, ForeignKey("cases.id", ondelete="CASCADE"), nullable=False, index=True)
-    case_title = Column(String(255), nullable=False)
-    deadline_date = Column(DateTime(timezone=True), nullable=False, index=True)
-    deadline_type = Column(String(255), nullable=False)  # appeal, filing, submission, etc.
-    description = Column(Text, nullable=True)
-    created_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), nullable=False)
-    updated_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), onupdate=lambda: dt.datetime.now(dt.timezone.utc))
-    is_completed = Column(Boolean, default=False, index=True)
-
-    # Relationships
-    case = relationship("Case", back_populates="deadlines")
-    notifications = relationship("NotificationLog", back_populates="deadline", cascade="all, delete-orphan")
-    attachments = relationship("Attachment", back_populates="deadline", cascade="all, delete-orphan")
-
-    def days_until_deadline(self) -> int:
-        """Calculate days remaining until deadline"""
-        now = dt.datetime.now(dt.timezone.utc)
-        deadline = self.deadline_date
-        if deadline and deadline.tzinfo is None:
-            deadline = deadline.replace(tzinfo=dt.timezone.utc)
-        delta = deadline - now
-        return max(0, delta.days)
-
-    def __repr__(self):
-        return f"<CaseDeadline(user_id={self.user_id}, case_id={self.case_id}, deadline_date={self.deadline_date})>"
-
-
-class UserPreference(Base):
-    """Model for user notification preferences"""
-    __tablename__ = "user_preferences"
-
-    id = Column(Integer, primary_key=True)
-    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), unique=True, nullable=False, index=True)
-    phone_number = Column(String(255), nullable=True)
-    email = Column(String(255), nullable=False)
-    notification_channel = Column(SQLEnum(NotificationChannel), default=NotificationChannel.BOTH)
-    timezone = Column(String(255), default="UTC")  # e.g., "Asia/Kolkata", "America/New_York"
-    notify_30_days = Column(Boolean, default=True)
-    notify_10_days = Column(Boolean, default=True)
-    notify_3_days = Column(Boolean, default=True)
-    notify_1_day = Column(Boolean, default=True)
-
-    # Holiday-aware reminder engine (MVP)
-    holiday_aware_reminders = Column(Boolean, default=False)
-    holiday_country = Column(String(255), nullable=True)  # e.g., "IN" (optional in MVP)
-    holiday_region = Column(String(255), nullable=True)   # e.g., "MH" / state/province (optional in MVP)
-    # JSON array of ISO dates: ["2026-01-26", "2026-03-29", ...]
-    holiday_calendar_json = Column(Text, nullable=True)
-
-    created_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc))
-    updated_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), onupdate=lambda: dt.datetime.now(dt.timezone.utc))
-
-
-    # Relationships
-    user = relationship("User", back_populates="preferences")
-
-    def __repr__(self):
-        return f"<UserPreference(user_id={self.user_id}, channel={self.notification_channel})>"
-
-
-class NotificationLog(Base):
-    """Model for tracking sent notifications"""
-    __tablename__ = "notification_logs"
-
-    id = Column(Integer, primary_key=True)
-    deadline_id = Column(Integer, ForeignKey("case_deadlines.id", ondelete="CASCADE"), nullable=False, index=True)
-    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
-    channel = Column(SQLEnum(NotificationChannel), nullable=False)
-    status = Column(SQLEnum(NotificationStatus), default=NotificationStatus.PENDING, index=True)
-    recipient = Column(String(255), nullable=False)  # phone or email
-    days_before = Column(Integer, nullable=False)  # 30, 10, 3, or 1 day reminder
-    message_id = Column(String(255), nullable=True)  # From Twilio or SendGrid
-    error_message = Column(Text, nullable=True)
-    message_preview = Column(Text, nullable=True)
-    sent_at = Column(DateTime(timezone=True), nullable=True)
-    delivered_at = Column(DateTime(timezone=True), nullable=True)
-    created_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), nullable=False)
-
-    # Relationships
-    deadline = relationship("CaseDeadline", back_populates="notifications")
-
-    def __repr__(self):
-        return f"<NotificationLog(user_id={self.user_id}, status={self.status}, channel={self.channel})>"
-
-
-class CaseRecord(Base):
-    """Model for tracking individual case records (anonymized)"""
-    __tablename__ = "case_records"
-
-    id = Column(Integer, primary_key=True)
-    hashed_case_id = Column(String(255), unique=True, nullable=False, index=True)  # Hashed ID for privacy
-    case_type = Column(String(255), nullable=False, index=True)  # civil, criminal, family, etc.
-    jurisdiction = Column(String(255), nullable=False, index=True)  # Delhi, Maharashtra, etc.
-    court_name = Column(String(255), nullable=True, index=True)  # District court, High court, etc.
-    judge_name = Column(String(255), nullable=True, index=True)  # Anonymized judge reference
-    plaintiff_type = Column(String(255), nullable=True)  # individual, organization, government
-    defendant_type = Column(String(255), nullable=True)
-    case_value = Column(String(255), nullable=True)  # value range: <1L, 1-5L, 5-10L, >10L
-    outcome = Column(String(255), nullable=False, index=True)  # plaintiff_won, defendant_won, settlement, dismissal
-    judgment_summary = Column(Text, nullable=True)  # Brief summary of judgment
-    created_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), nullable=False)
-    updated_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), onupdate=lambda: dt.datetime.now(dt.timezone.utc))
-
-    # Relationships
-    outcome_data = relationship("CaseOutcome", back_populates="case_record", uselist=False, cascade="all, delete-orphan")
-
-    def __repr__(self):
-        return f"<CaseRecord(case_type={self.case_type}, jurisdiction={self.jurisdiction}, outcome={self.outcome})>"
-
-
-class CaseOutcome(Base):
-    """Model for tracking appeal outcomes and follow-ups"""
-    __tablename__ = "case_outcomes"
-
-    id = Column(Integer, primary_key=True)
     case_id = Column(Integer, ForeignKey("case_records.id", ondelete="CASCADE"), nullable=False, unique=True, index=True)
     appeal_filed = Column(Boolean, default=False, nullable=False)
     appeal_date = Column(DateTime(timezone=True), nullable=True)

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,0 +1,45 @@
+from .session import engine, SessionLocal, init_db, db_session, get_db, _to_utc_datetime, _datetime_for_db
+
+from .models import (
+    NotificationStatus,
+    NotificationChannel,
+    UserPreference,
+    NotificationLog,
+    NotificationTemplate,
+    CaseDeadline,
+    User,
+    OTPVerification,
+    Case,
+)
+
+from .crud.notifications import (
+    create_case_deadline,
+    get_upcoming_deadlines,
+    has_notification_been_sent,
+    log_notification,
+    get_notification_history,
+)
+
+__all__ = [
+    "engine",
+    "SessionLocal",
+    "init_db",
+    "db_session",
+    "get_db",
+    "_to_utc_datetime",
+    "_datetime_for_db",
+    "NotificationStatus",
+    "NotificationChannel",
+    "UserPreference",
+    "NotificationLog",
+    "NotificationTemplate",
+    "CaseDeadline",
+    "User",
+    "OTPVerification",
+    "Case",
+    "create_case_deadline",
+    "get_upcoming_deadlines",
+    "has_notification_been_sent",
+    "log_notification",
+    "get_notification_history",
+]

--- a/db/base.py
+++ b/db/base.py
@@ -1,0 +1,3 @@
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()

--- a/db/crud/__init__.py
+++ b/db/crud/__init__.py
@@ -1,0 +1,1 @@
+"""CRUD package for database helper functions."""

--- a/db/crud/notifications.py
+++ b/db/crud/notifications.py
@@ -1,0 +1,109 @@
+import datetime as dt
+from typing import Optional, List
+from sqlalchemy.orm import Session
+from db.models.notifications import NotificationLog, NotificationStatus, NotificationChannel, NotificationTemplate, UserPreference
+from db.models.cases import CaseDeadline, Case
+
+
+def create_case_deadline(
+    db: Session,
+    user_id: int,
+    case_id: int,
+    case_title: str,
+    deadline_date: dt.datetime,
+    deadline_type: str,
+    description: Optional[str] = None,
+) -> CaseDeadline:
+    try:
+        normalized_case_id = int(case_id)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("case_id must be an integer matching cases.id") from exc
+
+    # Ownership validation (prevents creating deadlines for other users' cases)
+    case = db.query(Case).filter(Case.id == normalized_case_id).first()
+    if not case or case.user_id != user_id:
+        raise PermissionError(
+            "case_id not found or not owned by the provided user_id"
+        )
+    deadline = CaseDeadline(
+        user_id=user_id,
+        case_id=normalized_case_id,
+        case_title=case_title,
+        deadline_date=deadline_date,
+        deadline_type=deadline_type,
+        description=description,
+    )
+    db.add(deadline)
+    db.commit()
+    db.refresh(deadline)
+    return deadline
+
+
+def get_upcoming_deadlines(db: Session, days_before: int = 30) -> List[CaseDeadline]:
+    now_utc = dt.datetime.now(dt.timezone.utc)
+    target_utc = (now_utc + dt.timedelta(days=days_before)).replace(
+        hour=23, minute=59, second=59, microsecond=999999
+    )
+
+    now = now_utc
+    target_date = target_utc
+    return db.query(CaseDeadline).filter(
+        CaseDeadline.is_completed == False,
+        CaseDeadline.deadline_date <= target_date,
+        CaseDeadline.deadline_date > now,
+    ).all()
+
+
+def has_notification_been_sent(
+    db: Session,
+    deadline_id: int,
+    days_before: int,
+    channel: NotificationChannel,
+) -> bool:
+    return db.query(NotificationLog).filter(
+        NotificationLog.deadline_id == deadline_id,
+        NotificationLog.days_before == days_before,
+        NotificationLog.channel == channel,
+        NotificationLog.status.in_([NotificationStatus.SENT, NotificationStatus.OPENED]),
+    ).first() is not None
+
+
+def log_notification(
+    db: Session,
+    deadline_id: int,
+    user_id: int,
+    channel: NotificationChannel,
+    recipient: str,
+    days_before: int,
+    status: NotificationStatus = NotificationStatus.PENDING,
+    message_id: Optional[str] = None,
+    error_message: Optional[str] = None,
+    message_preview: Optional[str] = None,
+) -> NotificationLog:
+    log = NotificationLog(
+        deadline_id=deadline_id,
+        user_id=user_id,
+        channel=channel,
+        recipient=recipient,
+        days_before=days_before,
+        status=status,
+        message_id=message_id,
+        error_message=error_message,
+        message_preview=message_preview,
+        sent_at=dt.datetime.now(dt.timezone.utc) if status != NotificationStatus.PENDING else None,
+    )
+    db.add(log)
+    db.flush()
+    db.refresh(log)
+    return log
+
+
+def get_notification_history(db: Session, user_id: int, limit: int = 50) -> List[NotificationLog]:
+    return db.query(NotificationLog).filter(
+        NotificationLog.user_id == user_id
+    ).order_by(NotificationLog.created_at.desc()).limit(limit).all()
+
+
+def get_notification_template_for_user(db: Session, user_id: int):
+    return db.query(NotificationTemplate).filter(NotificationTemplate.user_id == user_id).first()
+

--- a/db/models/__init__.py
+++ b/db/models/__init__.py
@@ -1,0 +1,18 @@
+from .notifications import NotificationStatus, NotificationChannel, NotificationLog, NotificationTemplate, UserPreference
+from .cases import CaseDeadline, Case, CaseDocument, Attachment, CaseTimeline
+from .auth import User, OTPVerification
+
+__all__ = [
+    "NotificationStatus",
+    "NotificationChannel",
+    "NotificationLog",
+    "NotificationTemplate",
+    "UserPreference",
+    "CaseDeadline",
+    "Case",
+    "CaseDocument",
+    "Attachment",
+    "CaseTimeline",
+    "User",
+    "OTPVerification",
+]

--- a/db/models/auth.py
+++ b/db/models/auth.py
@@ -1,0 +1,46 @@
+import datetime as dt
+from sqlalchemy import Column, Integer, String, DateTime, Boolean
+from sqlalchemy.orm import relationship
+from db.base import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+    id = Column(Integer, primary_key=True)
+    email = Column(String(255), unique=True, nullable=False)
+    created_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), nullable=False)
+    last_login = Column(DateTime(timezone=True), nullable=True)
+    is_verified = Column(Boolean, default=True, nullable=False)
+
+    cases = relationship("Case", back_populates="user", cascade="all, delete-orphan")
+    preferences = relationship("UserPreference", back_populates="user", cascade="all, delete-orphan")
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "email": self.email,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "last_login": self.last_login.isoformat() if self.last_login else None,
+            "is_verified": self.is_verified,
+        }
+
+
+class OTPVerification(Base):
+    __tablename__ = "otp_verifications"
+    id = Column(Integer, primary_key=True)
+    email = Column(String(255), nullable=False, index=True)
+    otp_hash = Column(String(255), nullable=False)
+    created_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), nullable=False)
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    is_used = Column(Boolean, default=False, nullable=False)
+    failed_attempts = Column(Integer, default=0, nullable=False)
+    locked_until = Column(DateTime(timezone=True), nullable=True)
+
+    def is_locked(self) -> bool:
+        if self.locked_until is None:
+            return False
+        now = dt.datetime.now(dt.timezone.utc)
+        locked_until = self.locked_until
+        if locked_until.tzinfo is None:
+            locked_until = locked_until.replace(tzinfo=dt.timezone.utc)
+        return now < locked_until

--- a/db/models/cases.py
+++ b/db/models/cases.py
@@ -1,0 +1,109 @@
+import datetime as dt
+import enum
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    DateTime,
+    Boolean,
+    Text,
+    ForeignKey,
+    UniqueConstraint,
+    Index,
+)
+from sqlalchemy.orm import relationship
+from db.base import Base
+
+
+class CaseDeadline(Base):
+    __tablename__ = "case_deadlines"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False)
+    case_id = Column(Integer, ForeignKey("cases.id", ondelete="CASCADE"), nullable=False, index=True)
+    case_title = Column(String(255), nullable=False)
+    deadline_date = Column(DateTime(timezone=True), nullable=False, index=True)
+    deadline_type = Column(String(255), nullable=False)
+    description = Column(Text, nullable=True)
+    created_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), nullable=False)
+    updated_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), onupdate=lambda: dt.datetime.now(dt.timezone.utc))
+    is_completed = Column(Boolean, default=False, index=True)
+
+    case = relationship("Case", back_populates="deadlines")
+    notifications = relationship("NotificationLog", back_populates="deadline", cascade="all, delete-orphan")
+    attachments = relationship("Attachment", back_populates="deadline", cascade="all, delete-orphan")
+
+    def days_until_deadline(self) -> int:
+        now = dt.datetime.now(dt.timezone.utc)
+        deadline = self.deadline_date
+        if deadline and deadline.tzinfo is None:
+            deadline = deadline.replace(tzinfo=dt.timezone.utc)
+        delta = deadline - now
+        return max(0, delta.days)
+
+
+class Case(Base):
+    __tablename__ = "cases"
+    __table_args__ = (UniqueConstraint("user_id", "case_number", name="uq_user_case_number"),)
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    case_number = Column(String(255), nullable=False)
+    case_type = Column(String(255), nullable=False, index=True)
+    jurisdiction = Column(String(255), nullable=False, index=True)
+    status = Column(String(255), default="active", nullable=False)
+    title = Column(String(255), nullable=True)
+    created_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), nullable=False)
+    updated_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), onupdate=lambda: dt.datetime.now(dt.timezone.utc))
+
+    user = relationship("User", back_populates="cases")
+    documents = relationship("CaseDocument", back_populates="case", cascade="all, delete-orphan")
+    deadlines = relationship("CaseDeadline", back_populates="case", cascade="all, delete-orphan")
+    timeline_events = relationship("CaseTimeline", back_populates="case", cascade="all, delete-orphan")
+    attachments = relationship("Attachment", back_populates="case", cascade="all, delete-orphan")
+
+
+class CaseDocument(Base):
+    __tablename__ = "case_documents"
+
+    id = Column(Integer, primary_key=True)
+    case_id = Column(Integer, ForeignKey("cases.id", ondelete="CASCADE"), nullable=False, index=True)
+    document_type = Column(String(255), nullable=False)
+    document_content = Column(Text, nullable=True)
+    file_path = Column(String(255), nullable=True)
+    uploaded_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), nullable=False)
+    summary = Column(Text, nullable=True)
+    remedies = Column(Text, nullable=True)
+
+    case = relationship("Case", back_populates="documents")
+
+
+class Attachment(Base):
+    __tablename__ = "attachments"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    case_id = Column(Integer, ForeignKey("cases.id", ondelete="CASCADE"), nullable=True, index=True)
+    deadline_id = Column(Integer, ForeignKey("case_deadlines.id", ondelete="CASCADE"), nullable=True, index=True)
+    original_filename = Column(String(255), nullable=False)
+    stored_path = Column(String(1024), nullable=False)
+    content_type = Column(String(255), nullable=True)
+    size_bytes = Column(Integer, nullable=True)
+    uploaded_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), nullable=False)
+
+    case = relationship("Case", back_populates="attachments")
+    deadline = relationship("CaseDeadline", back_populates="attachments")
+
+
+class CaseTimeline(Base):
+    __tablename__ = "case_timeline"
+
+    id = Column(Integer, primary_key=True)
+    case_id = Column(Integer, ForeignKey("cases.id", ondelete="CASCADE"), nullable=False, index=True)
+    event_type = Column(String(255), nullable=False, index=True)
+    event_date = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), nullable=False, index=True)
+    description = Column(Text, nullable=False)
+    event_metadata = Column(Text, nullable=True)
+    created_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), nullable=False)
+
+    case = relationship("Case", back_populates="timeline_events")

--- a/db/models/notifications.py
+++ b/db/models/notifications.py
@@ -1,0 +1,74 @@
+import datetime as dt
+import enum
+from sqlalchemy import Column, Integer, String, DateTime, Boolean, Text, ForeignKey, Enum as SQLEnum, Index
+from sqlalchemy.orm import relationship
+from db.base import Base
+
+
+class NotificationStatus(str, enum.Enum):
+    PENDING = "pending"
+    SENT = "sent"
+    FAILED = "failed"
+    BOUNCED = "bounced"
+    OPENED = "opened"
+
+
+class NotificationChannel(str, enum.Enum):
+    SMS = "sms"
+    EMAIL = "email"
+    BOTH = "both"
+
+
+class UserPreference(Base):
+    __tablename__ = "user_preferences"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), unique=True, nullable=False, index=True)
+    phone_number = Column(String(255), nullable=True)
+    email = Column(String(255), nullable=False)
+    notification_channel = Column(SQLEnum(NotificationChannel), default=NotificationChannel.BOTH)
+    timezone = Column(String(255), default="UTC")
+    notify_30_days = Column(Boolean, default=True)
+    notify_10_days = Column(Boolean, default=True)
+    notify_3_days = Column(Boolean, default=True)
+    notify_1_day = Column(Boolean, default=True)
+    holiday_aware_reminders = Column(Boolean, default=False)
+    holiday_country = Column(String(255), nullable=True)
+    holiday_region = Column(String(255), nullable=True)
+    holiday_calendar_json = Column(Text, nullable=True)
+    created_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc))
+    updated_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), onupdate=lambda: dt.datetime.now(dt.timezone.utc))
+
+    user = relationship("User", back_populates="preferences")
+
+
+class NotificationTemplate(Base):
+    __tablename__ = "notification_templates"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), unique=True, nullable=False, index=True)
+    sms_template = Column(Text, nullable=True)
+    email_subject_template = Column(String(255), nullable=True)
+    email_html_template = Column(Text, nullable=True)
+    created_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), nullable=False)
+    updated_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), onupdate=lambda: dt.datetime.now(dt.timezone.utc))
+
+
+class NotificationLog(Base):
+    __tablename__ = "notification_logs"
+
+    id = Column(Integer, primary_key=True)
+    deadline_id = Column(Integer, ForeignKey("case_deadlines.id", ondelete="CASCADE"), nullable=False, index=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    channel = Column(SQLEnum(NotificationChannel), nullable=False)
+    status = Column(SQLEnum(NotificationStatus), default=NotificationStatus.PENDING, index=True)
+    recipient = Column(String(255), nullable=False)
+    days_before = Column(Integer, nullable=False)
+    message_id = Column(String(255), nullable=True)
+    error_message = Column(Text, nullable=True)
+    message_preview = Column(Text, nullable=True)
+    sent_at = Column(DateTime(timezone=True), nullable=True)
+    delivered_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), nullable=False)
+
+    deadline = relationship("CaseDeadline", back_populates="notifications")

--- a/db/session.py
+++ b/db/session.py
@@ -1,0 +1,58 @@
+import datetime as dt
+import logging
+from sqlalchemy import create_engine
+from sqlalchemy.engine import make_url
+from sqlalchemy.orm import sessionmaker
+from config import Config
+
+logger = logging.getLogger(__name__)
+
+DATABASE_URL = Config.DATABASE_URL
+_db_url = make_url(DATABASE_URL)
+_is_sqlite = _db_url.get_backend_name() == "sqlite"
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False} if _is_sqlite else {})
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, expire_on_commit=False, bind=engine)
+
+
+def _to_utc_datetime(value: dt.datetime) -> dt.datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=dt.timezone.utc)
+    return value.astimezone(dt.timezone.utc)
+
+
+def _datetime_for_db(value: dt.datetime) -> dt.datetime:
+    utc_value = _to_utc_datetime(value)
+    if _is_sqlite:
+        return utc_value.replace(tzinfo=None)
+    return utc_value
+
+
+def init_db():
+    # Import here to avoid circular imports at package import time
+    from .base import Base
+
+    Base.metadata.create_all(bind=engine)
+
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def db_session():
+    db = SessionLocal()
+    try:
+        yield db
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/notification_service.py
+++ b/notification_service.py
@@ -34,7 +34,7 @@ try:
 except ImportError:
     SendGridAPIClient = None
     Mail = None
-from database import (
+from db import (
     Case,
     NotificationStatus,
     NotificationChannel,

--- a/notifications/reminder_engine.py
+++ b/notifications/reminder_engine.py
@@ -1,0 +1,73 @@
+"""Reminder decision logic extracted for easy testing.
+
+Pure helper functions and an orchestration builder that converts upcoming
+deadlines into actionable reminder jobs (deadline, user_pref, days_left).
+"""
+from typing import Iterable, Tuple
+import datetime as dt
+import pytz
+from sqlalchemy.orm import Session
+
+from db.models.cases import CaseDeadline
+from db.models.notifications import UserPreference
+
+
+def should_process_threshold(days_left: int) -> bool:
+    """Return True when the days_left value matches configured thresholds."""
+    return days_left in (30, 10, 3, 1)
+
+
+def is_notify_enabled(days_left: int, user_preference: UserPreference) -> bool:
+    """Return True if the user has enabled reminders for this threshold."""
+    if user_preference is None:
+        return False
+    if days_left == 30:
+        return bool(user_preference.notify_30_days)
+    if days_left == 10:
+        return bool(user_preference.notify_10_days)
+    if days_left == 3:
+        return bool(user_preference.notify_3_days)
+    if days_left == 1:
+        return bool(user_preference.notify_1_day)
+    return False
+
+
+def is_reminder_time_for_user(user_timezone: str, reminder_hour: int = 8) -> bool:
+    """Return True when current hour in user's timezone equals `reminder_hour`.
+
+    Falls back to UTC when timezone is invalid.
+    """
+    try:
+        if not user_timezone or not isinstance(user_timezone, str):
+            raise ValueError("Invalid timezone type")
+        tz = pytz.timezone(user_timezone)
+        user_now = dt.datetime.now(tz)
+        return user_now.hour == reminder_hour
+    except (pytz.exceptions.UnknownTimeZoneError, ValueError, AttributeError):
+        # Fallback to UTC if timezone is invalid
+        user_now = dt.datetime.now(dt.timezone.utc)
+        return user_now.hour == reminder_hour
+
+
+def build_reminder_jobs(upcoming_deadlines: Iterable[CaseDeadline], db: Session) -> Iterable[Tuple[CaseDeadline, UserPreference, int]]:
+    """Yield (deadline, user_pref, days_left) for deadlines that should be processed.
+
+    This function centralizes threshold checks, preference lookup and timezone
+    eligibility so the scheduler can simply iterate and dispatch jobs.
+    """
+    for deadline in upcoming_deadlines:
+        days_left = deadline.days_until_deadline()
+        if not should_process_threshold(days_left):
+            continue
+
+        user_pref = db.query(UserPreference).filter(UserPreference.user_id == deadline.user_id).first()
+        if not user_pref:
+            continue
+
+        if not is_notify_enabled(days_left, user_pref):
+            continue
+
+        if not is_reminder_time_for_user(user_pref.timezone):
+            continue
+
+        yield (deadline, user_pref, days_left)

--- a/scheduler.py
+++ b/scheduler.py
@@ -72,8 +72,8 @@ from apscheduler.executors.pool import ThreadPoolExecutor, ProcessPoolExecutor
 
 # APPLICATION-SPECIFIC IMPORTS
 # ------------------------------------------------------------------------------
-from database import (
-    engine,          # Imported to provide the connection for the job store
+from db import (
+    engine,
     init_db,
     SessionLocal,
     get_upcoming_deadlines,

--- a/scheduler.py
+++ b/scheduler.py
@@ -79,6 +79,7 @@ from db import (
     get_upcoming_deadlines,
     UserPreference,
 )
+from notifications.reminder_engine import build_reminder_jobs
 from notification_service import NotificationService
 
 # This module is imported by app.py, which handles logging configuration
@@ -91,30 +92,7 @@ _scheduler: Optional[BackgroundScheduler] = None
 notification_service = NotificationService()
 
 
-def is_reminder_time_for_user(user_timezone: str, reminder_hour: int = 8) -> bool:
-
-    """
-
-    Check if current time matches the reminder hour in user's local timezone.
-    
-    Args:
-        user_timezone: User's timezone as IANA string (e.g., "Asia/Kolkata")
-        reminder_hour: Hour to send reminders (default 8 AM)
-    
-    Returns:
-        True if current time in user's timezone is within the reminder hour
-    """
-    try:
-        if not user_timezone or not isinstance(user_timezone, str):
-            raise ValueError("Invalid timezone type")
-        tz = pytz.timezone(user_timezone)
-        user_now = datetime.now(tz)
-        return user_now.hour == reminder_hour
-    except (pytz.exceptions.UnknownTimeZoneError, ValueError, AttributeError):
-        logger.warning(f"Invalid timezone '{user_timezone}', falling back to UTC")
-        # Fallback to UTC if timezone is invalid
-        user_now = datetime.now(timezone.utc)
-        return user_now.hour == reminder_hour
+# Reminder time logic moved to notifications.reminder_engine.build_reminder_jobs
 
 
 def check_and_send_reminders():
@@ -199,52 +177,13 @@ def check_and_send_reminders():
         logger.info(f"Found {len(upcoming_deadlines)} upcoming deadlines")
 
         sent_count = 0
-        for deadline in upcoming_deadlines:
-            days_left = deadline.days_until_deadline()
-            
-            # Only process deadlines at reminder thresholds
-            if days_left not in [30, 10, 3, 1]:
-                continue
-
+        # Build actionable reminder jobs using extracted decision logic
+        for deadline, user_preference, days_left in build_reminder_jobs(upcoming_deadlines, db):
             logger.info(f"Processing deadline: Case={deadline.case_id}, Days Left={days_left}")
-
-            # Get user preferences
-            user_preference = db.query(UserPreference).filter(
-                UserPreference.user_id == deadline.user_id
-            ).first()
-
-            if not user_preference:
-                logger.warning(f"No preferences found for user {deadline.user_id}. Skipping.")
-                continue
-            
-            # Check if it's currently 8 AM in the user's local timezone
-            if not is_reminder_time_for_user(user_preference.timezone):
-                logger.debug(
-
-                    f"Not 8 AM yet in user's timezone",
-                    user_id=deadline.user_id,
-                    user_timezone=user_preference.timezone,
-                )
-                continue
-
-            # Check if reminders should be sent based on preferences
-            should_notify = False
-            if days_left == 30 and user_preference.notify_30_days:
-                should_notify = True
-            if days_left == 10 and user_preference.notify_10_days:
-                should_notify = True
-            if days_left == 3 and user_preference.notify_3_days:
-                should_notify = True
-            if days_left == 1 and user_preference.notify_1_day:
-                should_notify = True
-
-            if not should_notify:
-                logger.debug(f"Notifications disabled for this threshold ({days_left} days)")
-                continue
 
             # Send reminders using the notification service
             results = notification_service.send_reminders(db, deadline, user_preference, days_left)
-            
+
             for res in results:
                 if res.success:
                     sent_count += 1


### PR DESCRIPTION
Done — I extracted the reminder decision logic and wired it into the scheduler.

- Added reminder_engine.py with:
  - `should_process_threshold(days_left) -> bool`
  - `is_notify_enabled(days_left, user_preference) -> bool`
  - `is_reminder_time_for_user(user_timezone, hour=8) -> bool`
  - `build_reminder_jobs(upcoming_deadlines, db) -> Iterable[(deadline, user_pref, days_left)]`

- Updated scheduler.py to use `build_reminder_jobs` and removed the inlined decision logic.

Files changed:
- Added: reminder_engine.py
- Edited: scheduler.py
- (Previous refactor work remains: db package and database.py shim.)

closes #492