### PR TITLE
Implement Salted Hashing for API Keys

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -105,11 +105,12 @@ def verify_token(token: str) -> Dict:
 
 class APIKey:
     """API Key model"""
-    def __init__(self, key_id: str, name: str, key_hash: str, created_at: datetime, 
+    def __init__(self, key_id: str, name: str, key_hash: str, key_salt: str, created_at: datetime, 
                  expires_at: Optional[datetime] = None):
         self.key_id = key_id
         self.name = name
         self.key_hash = key_hash
+        self.key_salt = key_salt
         self.created_at = created_at
         self.expires_at = expires_at
     
@@ -125,9 +126,14 @@ def generate_api_key() -> str:
     return secrets.token_urlsafe(32)
 
 
-def hash_api_key(key: str) -> str:
-    """Hash API key for storage"""
-    return hashlib.sha256(key.encode()).hexdigest()
+def hash_api_key(key: str, salt: str) -> str:
+    """Hash API key for storage with salt"""
+    return hashlib.sha256((salt + key).encode()).hexdigest()
+
+
+def verify_api_key(key: str, salt: str, key_hash: str) -> bool:
+    """Verify API key against salt and hash"""
+    return hash_api_key(key, salt) == key_hash
 
 
 def create_api_key_record(name: str, expires_in_days: Optional[int] = None) -> tuple[str, APIKey]:
@@ -137,7 +143,8 @@ def create_api_key_record(name: str, expires_in_days: Optional[int] = None) -> t
     that contains only the hashed value for persistence.
     """
     key = generate_api_key()
-    key_hash = hash_api_key(key)
+    salt = secrets.token_hex(16)
+    key_hash = hash_api_key(key, salt)
     created_at = datetime.utcnow()
     expires_at = None
 
@@ -148,6 +155,7 @@ def create_api_key_record(name: str, expires_in_days: Optional[int] = None) -> t
         key_id=f"key_{secrets.token_hex(8)}",
         name=name,
         key_hash=key_hash,
+        key_salt=salt,
         created_at=created_at,
         expires_at=expires_at,
     )

--- a/api/config.py
+++ b/api/config.py
@@ -1,6 +1,7 @@
 """
 API Configuration
 """
+import os
 from functools import lru_cache
 import tempfile
 from pathlib import Path

--- a/scratch/verify_api_key_fix.py
+++ b/scratch/verify_api_key_fix.py
@@ -1,0 +1,42 @@
+import sys
+import os
+from datetime import datetime
+
+# Add the project root to sys.path
+sys.path.append(os.getcwd())
+
+from api.auth import create_api_key_record, verify_api_key
+
+def test_salted_hashing():
+    print("Testing salted hashing for API keys...")
+    
+    # Create a new API key record
+    key, record = create_api_key_record("Test Key")
+    
+    print(f"Generated Key: {key}")
+    print(f"Key Hash: {record.key_hash}")
+    print(f"Key Salt: {record.key_salt}")
+    
+    # Verify the key
+    is_valid = verify_api_key(key, record.key_salt, record.key_hash)
+    print(f"Verification with correct key: {is_valid}")
+    assert is_valid == True
+    
+    # Verify with incorrect key
+    is_valid_wrong = verify_api_key("wrong-key", record.key_salt, record.key_hash)
+    print(f"Verification with wrong key: {is_valid_wrong}")
+    assert is_valid_wrong == False
+    
+    # Ensure hash is not the same as unsalted hash (SHA-256)
+    import hashlib
+    unsalted_hash = hashlib.sha256(key.encode()).hexdigest()
+    print(f"Unsalted Hash: {unsalted_hash}")
+    assert record.key_hash != unsalted_hash
+    print("Salted hashing verified successfully!")
+
+if __name__ == "__main__":
+    try:
+        test_salted_hashing()
+    except Exception as e:
+        print(f"Test failed: {e}")
+        sys.exit(1)


### PR DESCRIPTION
 Addresses brute-force and rainbow table risks for API keys (#524) by introducing per-key cryptographic salting.

Security: Replaced unsalted SHA-256 with salted SHA-256 using a unique 16-byte random salt per key.
Refactor: Updated APIKey model to store the salt and added a verify_api_key helper.
Bug Fix: Resolved a NameError in api/config.py by adding the missing os import, ensuring the API can correctly load environment variables.

### Closes #524 