### PR TITLE
Fix: Implement "fail-closed" rate limiter policy for AI and Auth endpoints

### DIFF
--- a/api/limiter.py
+++ b/api/limiter.py
@@ -139,14 +139,15 @@ class DistributedRateLimiter:
 
             return allowed
         except Exception as exc:
+            fail_open = not any(p in endpoint for p in ["/api/v1/analyze", "/api/v1/auth"])
             logger.error(
                 "rate_limiter_error",
                 error=str(exc),
                 identifier=identifier,
                 endpoint=endpoint,
-                fail_open=True,
+                fail_open=fail_open,
             )
-            return True
+            return fail_open
 
     async def get_remaining_ttl(self, identifier: str, endpoint: str, window_seconds: int) -> int:
         try:


### PR DESCRIPTION
Resolves #526. 

**Changes:**
- Modified `DistributedRateLimiter.check_rate_limit()` to fail closed instead of open when Redis is unreachable for high-cost operations.
- Targeted `/api/v1/analyze` and `/api/v1/auth` endpoints to return a `429 Too Many Requests` during cache failures, protecting the system against DDoS attacks.
- Standard low-cost endpoints continue to fail open (`True`) to ensure maximum availability.
- Updated telemetry logs to accurately reflect the dynamic `fail_open` status.
