### PR TITLE
Fix: Invalidate Streamlit RAG state when judgment document changes

### DIFF
--- a/core/rag_engine.py
+++ b/core/rag_engine.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 import re
 from typing import Dict, List, Optional
@@ -8,6 +9,14 @@ from langchain_community.vectorstores import Chroma
 from config import Config
 
 LOGGER = logging.getLogger(__name__)
+
+
+def get_judgment_hash(text: str) -> str:
+    """Generate an MD5 hash of judgment text to uniquely identify it."""
+    if not text:
+        return ""
+    return hashlib.md5(text.encode("utf-8")).hexdigest()
+
 
 class LegalRAG:
     def __init__(self, embedding_model_name: str = "all-MiniLM-L6-v2"):
@@ -29,6 +38,11 @@ class LegalRAG:
             chunk_overlap=180,
             separators=["\n\n", "\n", ".", " ", ""]
         )
+
+    def reset(self) -> None:
+        """Reset the vector store to clear loaded document state."""
+        LOGGER.info("Resetting LegalRAG vector store.")
+        self.vector_store = None
 
     def _is_section_header(self, line: str) -> bool:
         """Identify likely legal section headers so related rules stay together."""

--- a/pages/4_Chat.py
+++ b/pages/4_Chat.py
@@ -2,7 +2,7 @@ import streamlit as st
 import logging
 
 from core.app_utils import get_client, RETRO_STYLING
-from core.rag_engine import LegalRAG
+from core.rag_engine import LegalRAG, get_judgment_hash
 import routes
 
 # Apply the same styling as other pages
@@ -10,7 +10,7 @@ st.markdown(RETRO_STYLING, unsafe_allow_html=True)
 
 # Cache the RAG engine so we don't reload the embedding model on every interaction
 @st.cache_resource
-def get_rag_engine():
+def get_rag_engine(text_hash: str):
     return LegalRAG()
 
 def render_page():
@@ -23,6 +23,13 @@ def render_page():
             st.switch_page(routes.PAGE_HOME)
         return
 
+    # Invalidate and reset chat if the judgment document has changed
+    current_hash = get_judgment_hash(st.session_state.judgment_raw_text)
+    if st.session_state.get("last_judgment_hash") != current_hash:
+        st.session_state.chat_history = []
+        st.session_state.rag_initialized = False
+        st.session_state.last_judgment_hash = current_hash
+
     # Sidebar language preference
     language = st.session_state.get("judgment_language", "English")
     st.sidebar.markdown(f"**Chat Language:** {language}")
@@ -30,10 +37,15 @@ def render_page():
     
     if st.sidebar.button("🗑️ Clear Chat History", use_container_width=True):
         st.session_state.chat_history = []
+        st.session_state.rag_initialized = False
+        # Get cached engine and reset it
+        stale_hash = st.session_state.get("last_judgment_hash", "")
+        rag_engine = get_rag_engine(stale_hash)
+        rag_engine.reset()
         st.rerun()
 
     # Initialize RAG Engine
-    rag_engine = get_rag_engine()
+    rag_engine = get_rag_engine(current_hash)
     
     if "rag_initialized" not in st.session_state or not st.session_state.rag_initialized:
         with st.spinner("Initializing interactive chat... (this may take a moment to process the document)"):

--- a/tests/test_rag_invalidation.py
+++ b/tests/test_rag_invalidation.py
@@ -1,0 +1,77 @@
+"""
+Unit tests for RAG invalidation and state reset logic.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from core.rag_engine import LegalRAG, get_judgment_hash
+
+
+@pytest.fixture
+def mock_embeddings():
+    """Mock HuggingFaceEmbeddings to avoid model download / loading."""
+    with patch("core.rag_engine.HuggingFaceEmbeddings") as mock_hf:
+        mock_hf.return_value = MagicMock()
+        yield mock_hf
+
+
+def test_get_judgment_hash_valid():
+    """Test get_judgment_hash with valid string inputs."""
+    text1 = "This is a sample judgment text."
+    text2 = "This is a different judgment text."
+    
+    hash1 = get_judgment_hash(text1)
+    hash2 = get_judgment_hash(text2)
+    
+    assert len(hash1) == 32
+    assert len(hash2) == 32
+    assert hash1 != hash2
+    # Ensure same input yields same hash
+    assert get_judgment_hash(text1) == hash1
+
+
+def test_get_judgment_hash_empty_and_none():
+    """Test get_judgment_hash with empty or None input."""
+    assert get_judgment_hash("") == ""
+    assert get_judgment_hash(None) == ""
+
+
+def test_legal_rag_reset(mock_embeddings):
+    """Test that LegalRAG reset method clears the vector store."""
+    rag_engine = LegalRAG()
+    
+    # Manually assign a mock vector store
+    mock_vs = MagicMock()
+    rag_engine.vector_store = mock_vs
+    assert rag_engine.vector_store is not None
+    
+    # Reset
+    rag_engine.reset()
+    assert rag_engine.vector_store is None
+
+
+def test_invalidation_state_logic():
+    """Test the simulated session state invalidation logic flow."""
+    # Simulation of st.session_state
+    session_state = {
+        "judgment_raw_text": "Initial Document Text",
+        "chat_history": [{"role": "user", "content": "hello"}],
+        "rag_initialized": True,
+        "last_judgment_hash": get_judgment_hash("Initial Document Text")
+    }
+    
+    # 1. Simulate new document upload
+    session_state["judgment_raw_text"] = "New Document Text"
+    
+    # 2. Run invalidation helper logic (simulating pages/4_Chat.py logic)
+    current_hash = get_judgment_hash(session_state["judgment_raw_text"])
+    if session_state.get("last_judgment_hash") != current_hash:
+        session_state["chat_history"] = []
+        session_state["rag_initialized"] = False
+        session_state["last_judgment_hash"] = current_hash
+        
+    # 3. Assert states are correctly reset/invalidated
+    assert session_state["chat_history"] == []
+    assert session_state["rag_initialized"] is False
+    assert session_state["last_judgment_hash"] == current_hash


### PR DESCRIPTION
### Problem
The Streamlit Chat page (`pages/4_Chat.py`) globally caches `LegalRAG()` as a parameterless singleton via `@st.cache_resource`. Because the cached resource was not tied to the document's content, uploading a new judgment document on the Home page could result in the chat using the old vector store, or mixing up chat histories across documents. 

Additionally, clearing chat history did not drop the stale in-memory vector store.

### Solution
1. **Per-Document Caching**: Parameterized `@st.cache_resource def get_rag_engine(text_hash: str)` using an MD5 hash of `judgment_raw_text` so that unique documents get isolated `LegalRAG` instances and vector stores.
2. **State Invalidation**: Added a check at the top of the Chat page. If the document's MD5 hash changes, `st.session_state` is updated, and the chat history and indexing flag are reset.
3. **Stale Vector Dropping**: Introduced a `reset()` method to `LegalRAG` and wired it into the "Clear Chat History" button to cleanly drop the active Chroma vector store.
4. **Unit Tests**: Added offline-friendly, self-contained unit tests in `tests/test_rag_invalidation.py` to ensure hashing, reset, and invalidation state logic remain fully correct without downloading external model weights.

### Closes #582 