### PR TITLE
Fix: unify JWT secret env vars between Streamlit and FastAPI (issue #584)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,9 +88,11 @@ OCR_LANGUAGES="eng+hin"
 DATABASE_URL="sqlite:///./legalassist.db"
 
 # --- Authentication (JWT & OTP) ---
-# A strong, unique secret key for JWT signing. 
+# A strong, unique secret key for JWT signing (unified across UI and API).
 # If left blank in development, one will be generated and saved to .jwt_secret
 JWT_SECRET=""
+# Previous JWT secret key used for verification during key rotation / grace periods
+# JWT_SECRET_PREVIOUS=""
 # OTP_EXPIRY_MINUTES=10
 # OTP_MAX_ATTEMPTS=3
 

--- a/api/config.py
+++ b/api/config.py
@@ -56,7 +56,8 @@ class APISettings(BaseSettings):
     
     # Authentication
     AUTH_ENABLED: bool = True
-    JWT_SECRET_KEY: str = os.getenv("JWT_SECRET_KEY", "")
+    JWT_SECRET_KEY: str = os.getenv("JWT_SECRET", os.getenv("JWT_SECRET_KEY", ""))
+    JWT_SECRET_KEY_PREVIOUS: str = os.getenv("JWT_SECRET_PREVIOUS", os.getenv("JWT_SECRET_KEY_PREVIOUS", ""))
     JWT_ALGORITHM: str = "HS256"
     JWT_EXPIRATION_HOURS: int = 24
     JWT_ISSUER: str = os.getenv("JWT_ISSUER", "legalassist.ai")
@@ -68,7 +69,7 @@ class APISettings(BaseSettings):
     def validate_jwt_secret(cls, v: str) -> str:
         if not v or v == "your-secret-key-change-in-production":
             raise ValueError(
-                "JWT_SECRET_KEY must be set to a secure value. "
+                "JWT_SECRET (or JWT_SECRET_KEY) must be set to a secure value. "
                 "Do not use default or placeholder values in production."
             )
         return v
@@ -131,6 +132,18 @@ class APISettings(BaseSettings):
     ENABLE_ANALYTICS: bool = os.getenv("ENABLE_ANALYTICS", "true").lower() == "true"
     
     def __init__(self, **data):
+        # Enforce canonical env var precedence BEFORE Pydantic validates fields.
+        # JWT_SECRET takes priority over the legacy JWT_SECRET_KEY alias.
+        # Init kwargs have the highest priority in Pydantic v2 BaseSettings, so
+        # injecting here ensures the field_validator sees the canonical value.
+        if not data.get("JWT_SECRET_KEY"):
+            canonical = os.getenv("JWT_SECRET") or os.getenv("JWT_SECRET_KEY", "")
+            if canonical:
+                data["JWT_SECRET_KEY"] = canonical
+        if not data.get("JWT_SECRET_KEY_PREVIOUS"):
+            canonical_prev = os.getenv("JWT_SECRET_PREVIOUS") or os.getenv("JWT_SECRET_KEY_PREVIOUS", "")
+            if canonical_prev:
+                data["JWT_SECRET_KEY_PREVIOUS"] = canonical_prev
         super().__init__(**data)
         # Parse ALLOWED_HOSTS from environment
         hosts_env = os.getenv("APP_ALLOWED_HOSTS", "")

--- a/config.py
+++ b/config.py
@@ -131,7 +131,7 @@ class Config:
     JWT_ISSUER = _get_val("JWT_ISSUER", "legalassist.ai")
     JWT_AUDIENCE = _get_val("JWT_AUDIENCE", "legalassist-users")
     JWT_EXPIRY_HOURS = _get_int_env("JWT_EXPIRY_HOURS", 7 * 24)
-    JWT_SECRET_PREVIOUS = _get_val("JWT_SECRET_PREVIOUS", _get_val("JWT_SECRET_OLD", ""))
+    JWT_SECRET_PREVIOUS = _get_val("JWT_SECRET_PREVIOUS", _get_val("JWT_SECRET_KEY_PREVIOUS", _get_val("JWT_SECRET_OLD", "")))
     OTP_EXPIRY_MINUTES = _get_int_env("OTP_EXPIRY_MINUTES", 10)
     OTP_MAX_ATTEMPTS = _get_int_env("OTP_MAX_ATTEMPTS", 3)
     OTP_REQUEST_RATE_LIMIT_MAX = _get_int_env("OTP_REQUEST_RATE_LIMIT_MAX", 5)
@@ -163,7 +163,7 @@ class Config:
     @classmethod
     def get_current_jwt_secret(cls) -> str:
         """Return the active JWT signing secret without falling back to placeholders."""
-        return str(_get_val("JWT_SECRET", _get_val("JWT_SECRET_CURRENT", ""))).strip()
+        return str(_get_val("JWT_SECRET", _get_val("JWT_SECRET_KEY", _get_val("JWT_SECRET_CURRENT", "")))).strip()
 
     @classmethod
     def get_jwt_secrets(cls) -> list[str]:

--- a/tests/test_jwt_config_parity.py
+++ b/tests/test_jwt_config_parity.py
@@ -1,0 +1,90 @@
+"""
+Tests for JWT config parity between Streamlit (config.py/auth.py) and
+the FastAPI backend (api/config.py/api/auth.py).
+
+Ensures both stacks honour the canonical JWT_SECRET / JWT_SECRET_PREVIOUS
+env vars and fall back correctly to the legacy aliases.
+"""
+import os
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("CELERY_BROKER_URL", "redis://localhost:6379/1")
+os.environ.setdefault("CELERY_RESULT_BACKEND", "redis://localhost:6379/2")
+os.environ.setdefault("APP_ALLOWED_HOSTS", "localhost")
+
+import importlib
+
+from api.config import APISettings
+from config import Config
+
+
+def test_api_settings_canonical_precedence(monkeypatch):
+    """JWT_SECRET takes precedence over JWT_SECRET_KEY in APISettings."""
+    monkeypatch.setenv("JWT_SECRET", "canonical-secret-1234567890123456")
+    monkeypatch.setenv("JWT_SECRET_KEY", "legacy-secret-1234567890123456")
+    monkeypatch.setenv("JWT_SECRET_PREVIOUS", "canonical-prev-1234567890123456")
+    monkeypatch.setenv("JWT_SECRET_KEY_PREVIOUS", "legacy-prev-1234567890123456")
+
+    settings = APISettings()
+    assert settings.JWT_SECRET_KEY == "canonical-secret-1234567890123456"
+    assert settings.JWT_SECRET_KEY_PREVIOUS == "canonical-prev-1234567890123456"
+
+
+def test_api_settings_legacy_fallback(monkeypatch):
+    """JWT_SECRET_KEY is used when canonical JWT_SECRET is absent."""
+    monkeypatch.delenv("JWT_SECRET", raising=False)
+    monkeypatch.setenv("JWT_SECRET_KEY", "legacy-secret-1234567890123456")
+    monkeypatch.delenv("JWT_SECRET_PREVIOUS", raising=False)
+    monkeypatch.setenv("JWT_SECRET_KEY_PREVIOUS", "legacy-prev-1234567890123456")
+
+    settings = APISettings()
+    assert settings.JWT_SECRET_KEY == "legacy-secret-1234567890123456"
+    assert settings.JWT_SECRET_KEY_PREVIOUS == "legacy-prev-1234567890123456"
+
+
+def test_streamlit_config_canonical_precedence(monkeypatch):
+    """get_current_jwt_secret() returns JWT_SECRET over JWT_SECRET_KEY."""
+    monkeypatch.setenv("JWT_SECRET", "canonical-secret-1234567890123456")
+    monkeypatch.setenv("JWT_SECRET_KEY", "legacy-secret-1234567890123456")
+
+    assert Config.get_current_jwt_secret() == "canonical-secret-1234567890123456"
+
+
+def test_streamlit_config_legacy_fallback(monkeypatch):
+    """get_current_jwt_secret() falls back to JWT_SECRET_KEY."""
+    monkeypatch.delenv("JWT_SECRET", raising=False)
+    monkeypatch.setenv("JWT_SECRET_KEY", "legacy-secret-1234567890123456")
+
+    assert Config.get_current_jwt_secret() == "legacy-secret-1234567890123456"
+
+
+def test_streamlit_config_previous_secret_alias(monkeypatch):
+    """JWT_SECRET_PREVIOUS falls back to JWT_SECRET_KEY_PREVIOUS (class-level reload)."""
+    monkeypatch.delenv("JWT_SECRET_PREVIOUS", raising=False)
+    monkeypatch.setenv("JWT_SECRET_KEY_PREVIOUS", "legacy-prev-1234567890123456")
+
+    import config as config_mod
+    importlib.reload(config_mod)
+    assert config_mod.Config.JWT_SECRET_PREVIOUS == "legacy-prev-1234567890123456"
+
+
+def test_cross_stack_shared_secret(monkeypatch):
+    """A token signed with the canonical JWT_SECRET is decodable by both stacks."""
+    import jwt as pyjwt
+
+    secret = "shared-secret-key-1234567890123456"
+    monkeypatch.setenv("JWT_SECRET", secret)
+
+    # FastAPI side resolves the secret via APISettings
+    api_settings = APISettings()
+    assert api_settings.JWT_SECRET_KEY == secret
+
+    # Streamlit side resolves the secret dynamically
+    assert Config.get_current_jwt_secret() == secret
+
+    # A token encoded with that secret must be decodable by both
+    token = pyjwt.encode({"sub": "42", "email": "tester@example.com"}, secret, algorithm="HS256")
+    decoded_api = pyjwt.decode(token, api_settings.JWT_SECRET_KEY, algorithms=["HS256"], options={"verify_exp": False})
+    decoded_streamlit = pyjwt.decode(token, Config.get_current_jwt_secret(), algorithms=["HS256"], options={"verify_exp": False})
+
+    assert decoded_api["sub"] == "42"
+    assert decoded_streamlit["sub"] == "42"


### PR DESCRIPTION
## Problem
The Streamlit frontend consumed `JWT_SECRET` while the FastAPI backend
consumed `JWT_SECRET_KEY`. This caused silent misconfiguration (tokens
rejected cross-stack) and an `AttributeError` on key rotation because
`JWT_SECRET_KEY_PREVIOUS` was referenced in `api/auth.py` but missing
from `APISettings`.

## Solution
Designate `JWT_SECRET` / `JWT_SECRET_PREVIOUS` as the single canonical
variables for both stacks, with transparent fallback to the legacy
`JWT_SECRET_KEY` / `JWT_SECRET_KEY_PREVIOUS` aliases.

### api/config.py
- Added missing `JWT_SECRET_KEY_PREVIOUS` field
- `__init__` now injects canonical vars into Pydantic init kwargs *before*
  `super().__init__()` so the `field_validator` sees the correct value
- Updated validator error message to name `JWT_SECRET` as the primary var

### config.py
- `JWT_SECRET_PREVIOUS` falls back to `JWT_SECRET_KEY_PREVIOUS`
- `get_current_jwt_secret()` falls back to `JWT_SECRET_KEY`

### .env.example
- Clarifies `JWT_SECRET` as the unified variable; documents `JWT_SECRET_PREVIOUS`

## Tests
6 new isolated tests in `tests/test_jwt_config_parity.py` covering
canonical precedence, legacy fallback, and shared-secret decodability
for both stacks. All existing auth tests continue to pass.

## No breaking changes
Both old (`JWT_SECRET_KEY`) and new (`JWT_SECRET`) variable names work.
Operators can migrate at their own pace.

### Closes #584 