### PR TITLE
Fix: Secure WebSocket authentication via Sec-WebSocket-Protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ htmlcov/
 requirements.txt
 requirements.in
 /.venv
+.exports/

--- a/api/main.py
+++ b/api/main.py
@@ -257,15 +257,26 @@ if settings.ENABLE_WEBSOCKET:
         """
         WebSocket endpoint for real-time job progress
         
-        Requires authentication via token query parameter.
+        Requires authentication via token query parameter or Sec-WebSocket-Protocol header.
         """
-        if not token:
+        auth_token = token
+        requested_protocols = []
+        
+        if "sec-websocket-protocol" in websocket.headers:
+            header_val = websocket.headers["sec-websocket-protocol"]
+            requested_protocols = [p.strip() for p in header_val.split(",")]
+            if "access_token" in requested_protocols:
+                idx = requested_protocols.index("access_token")
+                if idx + 1 < len(requested_protocols):
+                    auth_token = requested_protocols[idx + 1]
+
+        if not auth_token:
             await websocket.close(code=4001, reason="Authentication required")
             return
         
         try:
             from api.auth import verify_token
-            payload = verify_token(token)
+            payload = verify_token(auth_token)
             user_id = payload.get("sub")
             
             if not user_id:
@@ -275,7 +286,8 @@ if settings.ENABLE_WEBSOCKET:
             await websocket.close(code=4001, reason="Invalid or expired token")
             return
         
-        await websocket.accept()
+        subprotocol = "access_token" if "access_token" in requested_protocols else None
+        await websocket.accept(subprotocol=subprotocol)
 
         async def stream_progress_updates():
             while True:

--- a/api/middleware.py
+++ b/api/middleware.py
@@ -145,56 +145,57 @@ async def logging_middleware(request: Request, call_next: Callable):
     response = None
     error_occurred = False
     
-    with traced_operation(
-        f"http {request.method} {endpoint}",
-        {
-            "http.method": request.method,
-            "http.target": endpoint,
-            "request.id": request_id,
-            "user.id": user_id,
-        },
-    ):
-        try:
-            response = await call_next(request)
-        except Exception as exc:
-            error_occurred = True
-            duration = time.time() - start_time
-            observe_request(endpoint, request.method, 500, duration)
-            logger.error(
-                "http_request_failed",
+    try:
+        with traced_operation(
+            f"http {request.method} {endpoint}",
+            {
+                "http.method": request.method,
+                "http.target": endpoint,
+                "request.id": request_id,
+                "user.id": user_id,
+            },
+        ):
+            try:
+                response = await call_next(request)
+            except Exception as exc:
+                error_occurred = True
+                duration = time.time() - start_time
+                observe_request(endpoint, request.method, 500, duration)
+                logger.error(
+                    "http_request_failed",
+                    method=request.method,
+                    path=endpoint,
+                    status_code=500,
+                    duration_ms=round(duration * 1000, 2),
+                    request_id=request_id,
+                    user_id=user_id,
+                    error=str(exc),
+                )
+                raise
+
+        process_time = time.time() - start_time
+        
+        if not error_occurred and response:
+            observe_request(endpoint, request.method, response.status_code, process_time)
+            
+            logger.info(
+                "http_request_completed",
                 method=request.method,
                 path=endpoint,
-                status_code=500,
-                duration_ms=round(duration * 1000, 2),
+                status_code=response.status_code,
+                duration_ms=round(process_time * 1000, 2),
                 request_id=request_id,
                 user_id=user_id,
-                error=str(exc),
             )
-            raise
-
-    process_time = time.time() - start_time
-    
-    if not error_occurred and response:
-        observe_request(endpoint, request.method, response.status_code, process_time)
+            
+            response.headers["X-Process-Time"] = str(process_time)
+            response.headers["X-Request-Id"] = request_id
         
-        logger.info(
-            "http_request_completed",
-            method=request.method,
-            path=endpoint,
-            status_code=response.status_code,
-            duration_ms=round(process_time * 1000, 2),
-            request_id=request_id,
-            user_id=user_id,
-        )
-        
-        response.headers["X-Process-Time"] = str(process_time)
-        response.headers["X-Request-Id"] = request_id
-    
-    clear_request_context()
-    return response
-except Exception:
-    clear_request_context()
-    raise
+        clear_request_context()
+        return response
+    except Exception:
+        clear_request_context()
+        raise
 
 
 def _request_size_limit_for_path(path: str) -> int:

--- a/sdk/javascript/client.js
+++ b/sdk/javascript/client.js
@@ -240,7 +240,8 @@ class LegalassistClient {
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
     const wsUrl = `${protocol}//${window.location.host}/ws/progress/${jobId}`;
 
-    const ws = new WebSocket(wsUrl);
+    const protocols = this.token ? ["access_token", this.token] : [];
+    const ws = new WebSocket(wsUrl, protocols);
 
     ws.onmessage = (event) => {
       const data = JSON.parse(event.data);

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -99,6 +99,25 @@ for case in results['results']:
     print(f"  Score: {case['relevance_score']}")
 ```
 
+### Real-time Progress Tracking (WebSocket)
+
+```python
+import websockets
+import json
+import asyncio
+
+async def track_progress(job_id, token):
+    url = f"ws://localhost:8000/ws/progress/{job_id}"
+    
+    # Pass token securely via Sec-WebSocket-Protocol
+    async with websockets.connect(url, subprotocols=["access_token", token]) as ws:
+        async for message in ws:
+            data = json.loads(message)
+            print(f"Progress: {data.get('progress')}% - {data.get('status')}")
+            if data.get('status') == 'completed':
+                break
+```
+
 ### Report Generation
 
 ```python

--- a/tests/test_websocket_auth.py
+++ b/tests/test_websocket_auth.py
@@ -1,0 +1,76 @@
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch, MagicMock
+
+# Assuming api.main exports 'app'
+from api.main import app
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+@patch("api.auth.verify_token")
+@patch("celery_app.TaskStatus.get_task_status")
+def test_websocket_auth_via_subprotocol(mock_get_task_status, mock_verify_token, client):
+    """Test that websocket connects successfully with valid token in subprotocols."""
+    mock_verify_token.return_value = {"sub": "user_123"}
+    # Mock task status to return completed so the loop exits immediately
+    mock_get_task_status.return_value = {
+        "status": "completed",
+        "info": {"progress": 100},
+        "timestamp": "2023-01-01T00:00:00Z"
+    }
+
+    token = "valid_token"
+    job_id = "job_123"
+    
+    with client.websocket_connect(f"/ws/progress/{job_id}", subprotocols=["access_token", token]) as websocket:
+        data = websocket.receive_json()
+        assert data["job_id"] == job_id
+        assert data["status"] == "completed"
+
+@patch("api.auth.verify_token")
+@patch("celery_app.TaskStatus.get_task_status")
+def test_websocket_auth_via_query(mock_get_task_status, mock_verify_token, client):
+    """Test that websocket connects successfully with valid token in query parameter (backward compatibility)."""
+    mock_verify_token.return_value = {"sub": "user_123"}
+    # Mock task status to return completed so the loop exits immediately
+    mock_get_task_status.return_value = {
+        "status": "completed",
+        "info": {"progress": 100},
+        "timestamp": "2023-01-01T00:00:00Z"
+    }
+
+    token = "valid_token"
+    job_id = "job_123"
+    
+    with client.websocket_connect(f"/ws/progress/{job_id}?token={token}") as websocket:
+        data = websocket.receive_json()
+        assert data["job_id"] == job_id
+        assert data["status"] == "completed"
+
+def test_websocket_auth_missing_token(client):
+    """Test that websocket rejects connection when no token is provided."""
+    job_id = "job_123"
+    try:
+        with client.websocket_connect(f"/ws/progress/{job_id}") as websocket:
+            pass
+        pytest.fail("Should have rejected connection")
+    except Exception as e:
+        # TestClient raises WebSocketDisconnect on rejection
+        assert hasattr(e, "code") or "4001" in str(e) or "403" in str(e) or type(e).__name__ == "WebSocketDisconnect"
+
+@patch("api.auth.verify_token")
+def test_websocket_auth_invalid_token(mock_verify_token, client):
+    """Test that websocket rejects connection when invalid token is provided."""
+    from api.auth import InvalidTokenError
+    mock_verify_token.side_effect = InvalidTokenError("Invalid token")
+    
+    token = "invalid_token"
+    job_id = "job_123"
+    try:
+        with client.websocket_connect(f"/ws/progress/{job_id}", subprotocols=["access_token", token]) as websocket:
+            pass
+        pytest.fail("Should have rejected connection")
+    except Exception as e:
+        assert hasattr(e, "code") or "4001" in str(e) or "403" in str(e) or type(e).__name__ == "WebSocketDisconnect"


### PR DESCRIPTION
Resolves #585.

This PR improves the security of the `/ws/progress/{job_id}` WebSocket endpoint by removing the requirement to pass the JWT authentication token in the URL query string, preventing token leakage in proxy logs and browser history.

**Changes:**
- **API**: Updated FastAPI WebSocket route to extract the auth token from the `Sec-WebSocket-Protocol` header. Fallback to `?token=` query param is maintained for backward compatibility.
- **JS SDK**: Modified `connectProgress` to securely pass the token as a subprotocol during initialization.
- **Python SDK**: Added a WebSocket progress tracking example to the README demonstrating secure token passing.
- **Tests**: Added `test_websocket_auth.py` to cover both subprotocol and query parameter authentication paths.
- **Misc**: Fixed an unrelated syntax error (dangling `except`) in `api/middleware.py` that was breaking the build.
