### PR TITLE
[High][Security] Restore Correct JWT Rotation Error Handling for Multi-Generation Key Validation

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -85,18 +85,21 @@ def verify_token(token: str) -> Dict:
                     options={"require": ["exp", "iat", "iss", "aud", "jti", "type"]},
                 )
                 break
+            except jwt.ExpiredSignatureError as exc:
+                last_error = exc
+                raise TokenExpiredError("Token has expired")
+            except jwt.InvalidIssuerError as exc:
+                last_error = exc
+                raise InvalidTokenError("Invalid token issuer")
+            except jwt.InvalidAudienceError as exc:
+                last_error = exc
+                raise InvalidTokenError("Invalid token audience")
             except jwt.InvalidTokenError as exc:
                 last_error = exc
                 continue
 
         if payload is None:
-            if isinstance(last_error, jwt.ExpiredSignatureError):
-                raise last_error
-            if isinstance(last_error, jwt.InvalidIssuerError):
-                raise last_error
-            if isinstance(last_error, jwt.InvalidAudienceError):
-                raise last_error
-            raise jwt.InvalidTokenError(str(last_error) if last_error else "Invalid token")
+            raise InvalidTokenError(str(last_error) if last_error else "Invalid token")
         if payload.get("type") != "access":
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,


### PR DESCRIPTION
📌 Description

This PR resolves a JWT validation and key-rotation reliability issue in api/auth.py within the verify_token workflow caused by incorrect exception handling order during multi-generation secret verification.

Previously, the JWT rotation mechanism iterated through multiple active signing secrets using _get_jwt_secrets_to_try() to support seamless key rotation and backward-compatible token validation.

Because the verification loop caught the generic jwt.InvalidTokenError before handling more specific JWT exception types, semantic error states were lost during multi-key validation attempts.

In particular:

JWT validation iterated across multiple active signing secrets
jwt.InvalidTokenError was caught before specific JWT exception subclasses
jwt.ExpiredSignatureError instances were absorbed by the generic catch block
Expired tokens from older key generations were treated as generic invalid tokens
Error handling behavior depended on key iteration order
Token expiration semantics became inconsistent across rotated signing keys

Because jwt.ExpiredSignatureError inherits from jwt.InvalidTokenError, expired tokens validated against rotated secrets lost their semantic expiration handling and were downgraded to generic invalid-token failures.

As a result:

Expired tokens could incorrectly surface as invalid-token errors
JWT rotation workflows lost deterministic expiration behavior
Graceful token renewal flows weakened significantly
Authentication error handling became inconsistent
Multi-generation key rotation safety guarantees degraded
Operational debugging of authentication failures became harder

This behavior introduced several operational and security reliability risks:

JWT rotation semantics became dependent on verification loop order
Expired tokens no longer produced stable error classifications
Authentication workflows behaved inconsistently during key rotation windows
Client token refresh handling became unreliable
Security telemetry lost accurate token expiration visibility
Key rotation reliability weakened under mixed-generation token usage

The updated implementation restores precise JWT exception handling by explicitly distinguishing expiration failures from generic signature validation failures during multi-key verification.

Expired tokens are now handled deterministically regardless of which signing key generation validates them, preserving consistent token lifecycle semantics across rotation workflows.

With these changes:

Expired tokens consistently raise TokenExpiredError
JWT rotation workflows preserve semantic expiration handling
Specific JWT exception types are handled deterministically
Multi-generation secret validation behaves predictably
Authentication error reporting becomes consistent
Graceful token refresh workflows remain reliable
JWT key rotation safety architecture functions correctly

These improvements strengthen authentication reliability, improve JWT rotation consistency, and restore deterministic expiration handling across multi-generation signing key workflows.

✨ Changes Included

Refactored JWT verification exception handling order
Added explicit handling for jwt.ExpiredSignatureError
Prevented semantic expiration states from being masked by generic validation errors
Improved consistency of multi-generation JWT key rotation handling
Restored deterministic token expiration behavior
Strengthened reliability of authentication error classification
Improved maintainability of JWT validation and rotation logic

🧪 Testing Done

Verified expired tokens consistently raise TokenExpiredError
Tested JWT validation across multiple rotated signing secrets
Validated deterministic behavior regardless of key iteration order
Confirmed generic invalid tokens remain rejected appropriately
Tested graceful token refresh workflows during key rotation windows
Verified authentication error classification consistency
Confirmed no regressions in existing JWT authentication workflows

closes #662 