### PR TITLE
[CI] Fail workflows on Bandit high-severity findings (#588)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,6 +119,28 @@ jobs:
           args: --severity-threshold=high
         continue-on-error: true
 
+      - name: Set up Python for Bandit
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+          
+      - name: Install Bandit
+        run: pip install bandit
+
+      - name: Run Bandit security scan
+        run: |
+          bandit -r api/ core/ auth.py celery_app.py -f json -o bandit-report.json || true
+          bandit -r api/ core/ auth.py celery_app.py -lll
+
+      - name: Upload Bandit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bandit-report-deploy
+          path: bandit-report.json
+          retention-days: 14
+
   # ==================== Build Docker Image ====================
   build:
     needs: test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,7 +93,16 @@ jobs:
     
     - name: Run Bandit security scan
       run: |
-        bandit -r core/ database.py notification_service.py scheduler.py -f json -o bandit-report.json || true
+        bandit -r api/ core/ auth.py celery_app.py -f json -o bandit-report.json || true
+        bandit -r api/ core/ auth.py celery_app.py -lll
+        
+    - name: Upload Bandit report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: bandit-report-tests
+        path: bandit-report.json
+        retention-days: 14
     
     - name: Check dependencies with Safety
       run: |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,6 +66,7 @@ We take the security of our legal assistance platform seriously. If you discover
 - Production deployments must use HTTPS at the ingress or load balancer; application URLs must begin with `https://`.
 - `DEBUG` and `TESTING` must remain disabled in production.
 - CI should run `scripts/check_secrets_policy.py` before deployment to catch committed secrets or unsafe defaults.
+- CI pipelines fail on HIGH severity Bandit findings. MEDIUM severity findings must be reviewed and ignored using `# nosec` only if justified.
 
 ---
 *Thank you for helping keep Legalassist-AI secure!* 🙏


### PR DESCRIPTION
Resolves #588 

**Changes:**
- Updated `.github/workflows/tests.yml` and `.github/workflows/deploy.yml` to fail the CI strictly on HIGH-severity Bandit findings using the `-lll` flag.
- Refined the scan targets to specifically check `api/`, `core/`, `auth.py`, and `celery_app.py`.
- Added a step to always upload `bandit-report.json` as a CI artifact.
- Documented in `SECURITY.md` that while HIGH severity fails the pipeline, MEDIUM severity issues must be triaged and safely ignored using `# nosec` where justified.
