### PR TITLE
fix:_extract_days_from_text can accept unintended matches

### DIFF
--- a/services/deadlines_auto_creator.py
+++ b/services/deadlines_auto_creator.py
@@ -12,6 +12,18 @@ from db.models import CaseDeadline
 from .timeline_service import timeline_service
 
 
+_APPEAL_DAY_PATTERNS = (
+    re.compile(
+        r"\b(?P<context>file(?:\s+an?)?\s+appeal|appeal|notice(?:\s+of)?\s+appeal|challenge(?:\s+an?)?(?:\s+order)?)\b.{0,40}?\b(?P<days>\d{1,3})\s*days?\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?P<days>\d{1,3})\s*days?\b.{0,40}?\b(?:to\s+)?(?P<context>file(?:\s+an?)?\s+appeal|appeal|notice(?:\s+of)?\s+appeal|challenge(?:\s+an?)?(?:\s+order)?)\b",
+        re.IGNORECASE,
+    ),
+)
+
+
 def _extract_days_from_text(text: str) -> Optional[int]:
     if not text or not isinstance(text, str):
         return None
@@ -21,13 +33,10 @@ def _extract_days_from_text(text: str) -> Optional[int]:
     if text.isdigit():
         return int(text)
 
-    primary_match = re.search(r"(\d+)\s*days?\b", text, re.IGNORECASE)
-    if primary_match:
-        return int(primary_match.group(1))
-
-    fallback_match = re.search(r"(?:in|within|after)\s+(\d+)\s*days?", text, re.IGNORECASE)
-    if fallback_match:
-        return int(fallback_match.group(1))
+    for pattern in _APPEAL_DAY_PATTERNS:
+        match = pattern.search(text)
+        if match:
+            return int(match.group("days"))
 
     return None
 

--- a/tests/test_deadlines_auto_creator.py
+++ b/tests/test_deadlines_auto_creator.py
@@ -6,13 +6,12 @@ from services.deadlines_auto_creator import _extract_days_from_text, _validate_d
 @pytest.mark.parametrize(
     "text, expected",
     [
-        ("30 days", 30),
         ("appeal within 15 days", 15),
         ("file appeal in 7 days", 7),
-        ("30days", 30),
-        ("30 Days", 30),
+        ("notice of appeal within 30 days", 30),
+        ("30 days to file appeal", 30),
+        ("challenge within 21 days", 21),
         ("Cost is 500 Rs, appeal in 30 days", 30),
-        ("within 21 days of service", 21),
     ],
 )
 def test_extract_days_from_text_variants(text, expected):
@@ -21,7 +20,18 @@ def test_extract_days_from_text_variants(text, expected):
 
 @pytest.mark.parametrize(
     "text",
-    ["", None, "Invalid text", "appeal by tomorrow"],
+    [
+        "",
+        None,
+        "Invalid text",
+        "appeal by tomorrow",
+        "30 days",
+        "30days",
+        "30 Days",
+        "within 21 days of service",
+        "payment due in 30 days",
+        "file payment in 30 days",
+    ],
 )
 def test_extract_days_from_text_invalid_inputs(text):
     assert _extract_days_from_text(text) is None


### PR DESCRIPTION
I tightened the deadline parser in deadlines_auto_creator.py so it only accepts day counts when they appear in explicit appeal contexts like appeal, file appeal, notice of appeal, or challenge, and I removed the generic days-only fallback that was causing false positives. The helper still accepts numeric days when the input is already just a number.

I updated the coverage in test_deadlines_auto_creator.py to keep the valid appeal phrasing and add near-miss cases that should now return None, including generic durations and non-appeal deadline language.

Validation: python -m py_compile deadlines_auto_creator.py test_deadlines_auto_creator.py passed. A direct pytest run on that test file is currently blocked by an unrelated collection import error in db.models about ReportStatus, which is outside this change.


closes #694