### PR TITLE
Background “Data Freshness” / RAG Invalidation Dashboard

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -34,7 +34,7 @@ from api.validation import (
 )
 
 # Import routes
-from api.routes import documents, cases, reports, analytics, deadlines, auth, health, case_search
+from api.routes import documents, cases, reports, analytics, deadlines, auth, health, case_search, knowledge
 from api.auth import get_current_user_optional
 
 settings = get_settings()
@@ -131,6 +131,7 @@ def create_app() -> FastAPI:
     app.include_router(deadlines.router)
     app.include_router(auth.router)
     app.include_router(case_search.router)  # Case search and precedent matching
+    app.include_router(knowledge.router)
     # Model feedback & optimization
     from api.routes import models as models_router
     app.include_router(models_router.router)

--- a/api/models.py
+++ b/api/models.py
@@ -345,6 +345,37 @@ class UpcomingDeadlinesResponse(BaseModel):
 
 
 # ============================================================================
+# Knowledge Freshness Models
+# ============================================================================
+
+class KnowledgeInvalidationItem(BaseModel):
+    id: int
+    user_id: Optional[int] = None
+    case_id: Optional[int] = None
+    document_id: Optional[int] = None
+    scope_type: str
+    scope_value: str
+    reason: str
+    details: Optional[Dict[str, Any]] = None
+    status: str
+    invalidated_at: datetime
+    scheduled_for: Optional[datetime] = None
+    recompute_started_at: Optional[datetime] = None
+    recompute_completed_at: Optional[datetime] = None
+    error_message: Optional[str] = None
+    recompute_attempts: int = 0
+
+
+class KnowledgeInvalidationListResponse(BaseModel):
+    items: List[KnowledgeInvalidationItem]
+    total: int
+    stale_count: int
+    fresh_count: int
+    next_recompute_at: Optional[datetime] = None
+    generated_at: datetime
+
+
+# ============================================================================
 # User Models
 # ============================================================================
 

--- a/api/routes/knowledge.py
+++ b/api/routes/knowledge.py
@@ -1,0 +1,74 @@
+"""Knowledge freshness and invalidation endpoints."""
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from api.auth import CurrentUser, get_current_user
+from api.models import KnowledgeInvalidationItem, KnowledgeInvalidationListResponse
+from db.crud.knowledge import get_knowledge_freshness_summary, list_knowledge_invalidations
+from database import get_db
+
+
+router = APIRouter(prefix="/api/v1/knowledge", tags=["knowledge"])
+
+
+@router.get("/invalidations", response_model=KnowledgeInvalidationListResponse, summary="List knowledge invalidations")
+async def list_invalidations(
+    case_id: int | None = Query(default=None),
+    document_id: int | None = Query(default=None),
+    status: str | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=200),
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> KnowledgeInvalidationListResponse:
+    """Return the invalidation ledger for the current user.
+
+    Admin users can still see their own invalidations; this endpoint keeps the
+    initial scope user-centric and can be expanded later with org-level filters.
+    """
+
+    rows = list_knowledge_invalidations(
+        db,
+        user_id=current_user.user_id if current_user.role != "admin" else None,
+        case_id=case_id,
+        document_id=document_id,
+        status=status,
+        limit=limit,
+    )
+    summary = get_knowledge_freshness_summary(
+        db,
+        user_id=current_user.user_id if current_user.role != "admin" else None,
+        case_id=case_id,
+    )
+
+    items = [
+        KnowledgeInvalidationItem(
+            id=row.id,
+            user_id=row.user_id,
+            case_id=row.case_id,
+            document_id=row.document_id,
+            scope_type=row.scope_type,
+            scope_value=row.scope_value,
+            reason=row.reason,
+            details=row.details,
+            status=row.status,
+            invalidated_at=row.invalidated_at,
+            scheduled_for=row.scheduled_for,
+            recompute_started_at=row.recompute_started_at,
+            recompute_completed_at=row.recompute_completed_at,
+            error_message=row.error_message,
+            recompute_attempts=row.recompute_attempts,
+        )
+        for row in rows
+    ]
+
+    return KnowledgeInvalidationListResponse(
+        items=items,
+        total=summary["total"],
+        stale_count=summary["stale"],
+        fresh_count=summary["fresh"],
+        next_recompute_at=summary["next_recompute_at"],
+        generated_at=datetime.now(timezone.utc),
+    )

--- a/database.py
+++ b/database.py
@@ -54,6 +54,12 @@ from db.crud.notifications import (
     has_notification_been_sent,
     log_notification,
 )
+from db.crud.knowledge import (
+    record_knowledge_invalidation,
+    list_knowledge_invalidations,
+    get_knowledge_freshness_summary,
+    process_due_knowledge_invalidations,
+)
 from db.models import (
     Attachment,
     Case,
@@ -71,6 +77,8 @@ from db.models import (
     CaseNoteVersion,
     DocumentType,
     KnowledgeGraphEdge,
+    KnowledgeInvalidation,
+    KnowledgeInvalidationStatus,
     ModelFeedback,
     ModelPerformance,
     ModelRoutingRule,
@@ -146,6 +154,8 @@ __all__ = [
     "CaseArgument",
     "KnowledgeGraphEdge",
     "PrecedentMatch",
+    "KnowledgeInvalidation",
+    "KnowledgeInvalidationStatus",
     "Report",
     "create_case_deadline",
     "get_upcoming_deadlines",
@@ -200,6 +210,10 @@ __all__ = [
     "submit_similarity_feedback",
     "get_similarity_feedback",
     "aggregate_model_performance",
+    "record_knowledge_invalidation",
+    "list_knowledge_invalidations",
+    "get_knowledge_freshness_summary",
+    "process_due_knowledge_invalidations",
 ]
 
 

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -22,6 +22,12 @@ from .crud.notifications import (
     log_notification,
     get_notification_history,
 )
+from .crud.knowledge import (
+    record_knowledge_invalidation,
+    list_knowledge_invalidations,
+    get_knowledge_freshness_summary,
+    process_due_knowledge_invalidations,
+)
 from .crud.feedback import submit_user_feedback, get_user_feedback
 
 __all__ = [
@@ -51,4 +57,8 @@ __all__ = [
     "get_notification_history",
     "submit_user_feedback",
     "get_user_feedback",
+    "record_knowledge_invalidation",
+    "list_knowledge_invalidations",
+    "get_knowledge_freshness_summary",
+    "process_due_knowledge_invalidations",
 ]

--- a/db/case_service.py
+++ b/db/case_service.py
@@ -18,6 +18,7 @@ from db.models import (
     ModelFeedback,
     UserFeedback,
 )
+from db.crud.knowledge import record_knowledge_invalidation
 
 
 def create_case(db: Session, user_id: int, case_number: str, case_type: str, jurisdiction: str, title: Optional[str] = None) -> Case:
@@ -103,6 +104,20 @@ def create_case_document(
     db.add(doc)
     db.commit()
     db.refresh(doc)
+
+    record_knowledge_invalidation(
+        db,
+        scope_type="case",
+        case_id=case_id,
+        document_id=doc.id,
+        user_id=user_id,
+        reason="document_created",
+        details={
+            "document_type": getattr(document_type, "value", document_type),
+            "source_attachment_id": source_attachment_id,
+            "changed_fields": ["document_content", "summary", "remedies", "extracted_metadata"],
+        },
+    )
     return doc
 
 
@@ -236,21 +251,42 @@ def update_case_document(
     """Update case document"""
     doc = db.query(CaseDocument).filter(CaseDocument.id == document_id).first()
     if doc:
+        changed_fields = []
         if document_content is not None:
             doc.document_content = document_content
+            changed_fields.append("document_content")
         if summary is not None:
             doc.summary = summary
+            changed_fields.append("summary")
         if remedies is not None:
             doc.remedies = remedies
+            changed_fields.append("remedies")
         if extracted_metadata is not None:
             doc.extracted_metadata = extracted_metadata
+            changed_fields.append("extracted_metadata")
         if extraction_method is not None:
             doc.extraction_method = extraction_method
+            changed_fields.append("extraction_method")
         if ocr_used is not None:
             doc.ocr_used = ocr_used
+            changed_fields.append("ocr_used")
         try:
             db.commit()
             db.refresh(doc)
+            if changed_fields:
+                reason = f"{changed_fields[0]}_updated"
+                record_knowledge_invalidation(
+                    db,
+                    scope_type="case",
+                    case_id=doc.case_id,
+                    document_id=doc.id,
+                    reason=reason,
+                    details={
+                        "changed_fields": changed_fields,
+                        "document_id": doc.id,
+                        "case_id": doc.case_id,
+                    },
+                )
         except Exception as e:
             db.rollback()
             raise RuntimeError(f"Database write failed for case document {document_id}: {str(e)}") from e

--- a/db/crud/__init__.py
+++ b/db/crud/__init__.py
@@ -8,6 +8,12 @@ from .reports import (
     list_reports_by_user,
     list_reports_by_case,
 )
+from .knowledge import (
+    record_knowledge_invalidation,
+    list_knowledge_invalidations,
+    get_knowledge_freshness_summary,
+    process_due_knowledge_invalidations,
+)
 
 __all__ = [
     "create_report",
@@ -16,5 +22,9 @@ __all__ = [
     "update_report_status",
     "list_reports_by_user",
     "list_reports_by_case",
+    "record_knowledge_invalidation",
+    "list_knowledge_invalidations",
+    "get_knowledge_freshness_summary",
+    "process_due_knowledge_invalidations",
 ]
 

--- a/db/crud/knowledge.py
+++ b/db/crud/knowledge.py
@@ -1,0 +1,192 @@
+import datetime as dt
+from typing import Any, Callable, Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+from db.models import (
+    Case,
+    CaseDocument,
+    KnowledgeInvalidation,
+    KnowledgeInvalidationStatus,
+)
+
+
+def _utcnow() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def _scope_value(scope_type: str, case_id: Optional[int], document_id: Optional[int], explicit_scope_value: Optional[str]) -> str:
+    if explicit_scope_value:
+        return explicit_scope_value
+    if scope_type == "document" and document_id is not None:
+        return f"document:{document_id}"
+    if case_id is not None:
+        return f"case:{case_id}"
+    return scope_type
+
+
+def record_knowledge_invalidation(
+    db: Session,
+    *,
+    scope_type: str,
+    reason: str,
+    case_id: Optional[int] = None,
+    document_id: Optional[int] = None,
+    user_id: Optional[int] = None,
+    scope_value: Optional[str] = None,
+    details: Optional[Dict[str, Any]] = None,
+    scheduled_for: Optional[dt.datetime] = None,
+) -> KnowledgeInvalidation:
+    invalidation = KnowledgeInvalidation(
+        user_id=user_id,
+        case_id=case_id,
+        document_id=document_id,
+        scope_type=scope_type,
+        scope_value=_scope_value(scope_type, case_id, document_id, scope_value),
+        reason=reason,
+        details=details or {},
+        status=KnowledgeInvalidationStatus.PENDING.value,
+        invalidated_at=_utcnow(),
+        scheduled_for=scheduled_for or _utcnow(),
+    )
+    db.add(invalidation)
+    db.commit()
+    db.refresh(invalidation)
+    return invalidation
+
+
+def list_knowledge_invalidations(
+    db: Session,
+    *,
+    user_id: Optional[int] = None,
+    case_id: Optional[int] = None,
+    document_id: Optional[int] = None,
+    status: Optional[str] = None,
+    limit: int = 50,
+) -> List[KnowledgeInvalidation]:
+    query = db.query(KnowledgeInvalidation)
+
+    if user_id is not None:
+        query = query.filter(KnowledgeInvalidation.user_id == user_id)
+    if case_id is not None:
+        query = query.filter(KnowledgeInvalidation.case_id == case_id)
+    if document_id is not None:
+        query = query.filter(KnowledgeInvalidation.document_id == document_id)
+    if status is not None:
+        query = query.filter(KnowledgeInvalidation.status == status)
+
+    return (
+        query.order_by(KnowledgeInvalidation.invalidated_at.desc())
+        .limit(limit)
+        .all()
+    )
+
+
+def get_knowledge_freshness_summary(
+    db: Session,
+    *,
+    user_id: Optional[int] = None,
+    case_id: Optional[int] = None,
+) -> Dict[str, Any]:
+    query = db.query(KnowledgeInvalidation)
+    if user_id is not None:
+        query = query.filter(KnowledgeInvalidation.user_id == user_id)
+    if case_id is not None:
+        query = query.filter(KnowledgeInvalidation.case_id == case_id)
+
+    rows = query.all()
+    stale_rows = [row for row in rows if row.status != KnowledgeInvalidationStatus.COMPLETED.value]
+    next_recompute_at = None
+    if stale_rows:
+        scheduled_times = [row.scheduled_for for row in stale_rows if row.scheduled_for]
+        if scheduled_times:
+            next_recompute_at = min(scheduled_times)
+
+    latest = max(rows, key=lambda row: row.invalidated_at, default=None)
+    return {
+        "total": len(rows),
+        "stale": len(stale_rows),
+        "fresh": len(rows) - len(stale_rows),
+        "next_recompute_at": next_recompute_at,
+        "latest": latest,
+    }
+
+
+def _recompute_case_scope(db: Session, invalidation: KnowledgeInvalidation) -> bool:
+    case_id = invalidation.case_id
+    document_id = invalidation.document_id
+
+    if case_id is None and document_id is None and invalidation.scope_value.startswith("case:"):
+        try:
+            case_id = int(invalidation.scope_value.split(":", 1)[1])
+        except (TypeError, ValueError):
+            case_id = None
+
+    if document_id is not None and case_id is None:
+        document = db.query(CaseDocument).filter(CaseDocument.id == document_id).first()
+        if document:
+            case_id = document.case_id
+
+    if case_id is None:
+        return True
+
+    from core.embedding_engine import EmbeddingEngine
+
+    engine = EmbeddingEngine()
+    if document_id is not None:
+        return engine.embed_case(db, case_id=case_id, document_id=document_id, force_regenerate=True) is not None
+
+    return engine.embed_case(db, case_id=case_id, force_regenerate=True) is not None
+
+
+def process_due_knowledge_invalidations(
+    db: Session,
+    *,
+    now: Optional[dt.datetime] = None,
+    limit: int = 20,
+    recompute_handler: Optional[Callable[[Session, KnowledgeInvalidation], bool]] = None,
+) -> List[KnowledgeInvalidation]:
+    now = now or _utcnow()
+    recompute_handler = recompute_handler or _recompute_case_scope
+
+    pending = (
+        db.query(KnowledgeInvalidation)
+        .filter(
+            KnowledgeInvalidation.status.in_(
+                [
+                    KnowledgeInvalidationStatus.PENDING.value,
+                    KnowledgeInvalidationStatus.FAILED.value,
+                ]
+            ),
+            KnowledgeInvalidation.scheduled_for <= now,
+        )
+        .order_by(KnowledgeInvalidation.scheduled_for.asc(), KnowledgeInvalidation.invalidated_at.asc())
+        .limit(limit)
+        .all()
+    )
+
+    processed: List[KnowledgeInvalidation] = []
+    for invalidation in pending:
+        invalidation.status = KnowledgeInvalidationStatus.PROCESSING.value
+        invalidation.recompute_attempts += 1
+        invalidation.recompute_started_at = now
+        db.commit()
+        db.refresh(invalidation)
+
+        try:
+            recomputed = recompute_handler(db, invalidation)
+            if not recomputed:
+                raise RuntimeError("Recompute handler returned no result")
+
+            invalidation.status = KnowledgeInvalidationStatus.COMPLETED.value
+            invalidation.recompute_completed_at = _utcnow()
+            invalidation.error_message = None
+        except Exception as exc:
+            invalidation.status = KnowledgeInvalidationStatus.FAILED.value
+            invalidation.error_message = str(exc)
+        finally:
+            db.commit()
+            db.refresh(invalidation)
+            processed.append(invalidation)
+
+    return processed

--- a/db/models/__init__.py
+++ b/db/models/__init__.py
@@ -18,6 +18,7 @@ from .analytics import (
     KnowledgeGraphEdge,
     PrecedentMatch,
 )
+from .knowledge import KnowledgeInvalidation, KnowledgeInvalidationStatus
 
 __all__ = [
     "NotificationStatus",
@@ -55,5 +56,7 @@ __all__ = [
     "CaseArgument",
     "KnowledgeGraphEdge",
     "PrecedentMatch",
+    "KnowledgeInvalidation",
+    "KnowledgeInvalidationStatus",
 ]
 

--- a/db/models/knowledge.py
+++ b/db/models/knowledge.py
@@ -1,0 +1,49 @@
+import datetime as dt
+import enum
+
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Text, JSON, Index
+from sqlalchemy.orm import relationship
+
+from db.base import Base
+
+
+class KnowledgeInvalidationStatus(str, enum.Enum):
+    PENDING = "pending"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class KnowledgeInvalidation(Base):
+    __tablename__ = "knowledge_invalidations"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=True, index=True)
+    case_id = Column(Integer, ForeignKey("cases.id", ondelete="CASCADE"), nullable=True, index=True)
+    document_id = Column(Integer, ForeignKey("case_documents.id", ondelete="CASCADE"), nullable=True, index=True)
+    scope_type = Column(String(50), nullable=False, index=True)
+    scope_value = Column(String(255), nullable=False, index=True)
+    reason = Column(String(255), nullable=False, index=True)
+    details = Column(JSON, nullable=True)
+    status = Column(String(50), default=KnowledgeInvalidationStatus.PENDING.value, nullable=False, index=True)
+    invalidated_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), nullable=False, index=True)
+    scheduled_for = Column(DateTime(timezone=True), nullable=True, index=True)
+    recompute_started_at = Column(DateTime(timezone=True), nullable=True)
+    recompute_completed_at = Column(DateTime(timezone=True), nullable=True)
+    error_message = Column(Text, nullable=True)
+    recompute_attempts = Column(Integer, default=0, nullable=False)
+    updated_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), onupdate=lambda: dt.datetime.now(dt.timezone.utc))
+
+    user = relationship("User")
+    case = relationship("Case")
+    document = relationship("CaseDocument")
+
+    __table_args__ = (
+        Index("ix_knowledge_invalidations_scope", "scope_type", "scope_value", "status"),
+    )
+
+    def __repr__(self):
+        return (
+            f"<KnowledgeInvalidation(scope={self.scope_type}:{self.scope_value}, "
+            f"reason={self.reason}, status={self.status})>"
+        )

--- a/pages/2_Case_Details.py
+++ b/pages/2_Case_Details.py
@@ -12,6 +12,7 @@ import routes
 from case_manager import get_case_detail, upload_case_document, mark_deadline_completed, mark_deadline_incomplete, add_manual_deadline, mark_case_appealed, mark_case_closed, mark_case_active, generate_case_summary_text
 from case_manager import upload_case_attachment, get_case_note_state, save_case_note, publish_case_note_for_case, get_case_note_history_for_case
 from core import extract_text_from_pdf
+from db.crud.knowledge import get_knowledge_freshness_summary, list_knowledge_invalidations
 from database import DocumentType, CaseStatus, SessionLocal, UserPreference
 import pytz
 import html
@@ -523,6 +524,61 @@ def render_remedies_section(remedies: Optional[Dict]):
                 st.write(span_text)
 
 
+def render_knowledge_status_section(case_id: int, user_id: int):
+    """Render the freshness dashboard for document-backed knowledge."""
+    st.subheader("📡 Knowledge Status")
+
+    db = SessionLocal()
+    try:
+        summary = get_knowledge_freshness_summary(db, user_id=user_id, case_id=case_id)
+        invalidations = list_knowledge_invalidations(db, user_id=user_id, case_id=case_id, limit=20)
+    finally:
+        db.close()
+
+    col1, col2, col3 = st.columns(3)
+    with col1:
+        st.metric("Fresh", summary["fresh"])
+    with col2:
+        st.metric("Stale", summary["stale"])
+    with col3:
+        next_run = summary.get("next_recompute_at")
+        st.metric(
+            "Next recompute",
+            next_run.strftime("%d %b %H:%M UTC") if next_run else "queued on demand",
+        )
+
+    latest = summary.get("latest")
+    if latest:
+        st.info(f"Latest invalidation: {latest.reason} at {latest.invalidated_at.strftime('%d %b %Y %H:%M UTC')}")
+    else:
+        st.success("No invalidations recorded for this case yet.")
+
+    if not invalidations:
+        st.caption("Nothing stale right now.")
+        return
+
+    for invalidation in invalidations:
+        stale_badge = "🟠" if invalidation.status != "completed" else "🟢"
+        with st.container(border=True):
+            st.markdown(f"{stale_badge} **{invalidation.scope_type.title()}** · {invalidation.scope_value}")
+            st.caption(f"Reason: {invalidation.reason} · Status: {invalidation.status}")
+            st.caption(
+                f"Invalidated: {invalidation.invalidated_at.strftime('%d %b %Y %H:%M UTC')}"
+                + (
+                    f" · Recompute: {invalidation.scheduled_for.strftime('%d %b %Y %H:%M UTC')}"
+                    if invalidation.scheduled_for
+                    else ""
+                )
+            )
+            details = invalidation.details or {}
+            if details:
+                changed_fields = details.get("changed_fields")
+                if changed_fields:
+                    st.write(f"Changed fields: {', '.join(changed_fields)}")
+                elif details:
+                    st.json(details)
+
+
 def render_case_actions(case: Dict, user_id: int):
     """Render case status actions"""
     st.subheader("🔧 Case Actions")
@@ -621,7 +677,7 @@ def main():
     st.markdown("---")
 
     # Main content - tabs
-    tab1, tab2, tab3, tab4, tab5 = st.tabs(["📅 Timeline", "📄 Documents", "⏰ Deadlines", "⚖️ Remedies", "🗒️ Notes"])
+    tab1, tab2, tab3, tab4, tab5, tab6 = st.tabs(["📅 Timeline", "📄 Documents", "⏰ Deadlines", "⚖️ Remedies", "📡 Knowledge", "🗒️ Notes"])
 
     with tab1:
         render_timeline_section(timeline)
@@ -636,6 +692,9 @@ def main():
         render_remedies_section(remedies)
 
     with tab5:
+        render_knowledge_status_section(case_id, user_id)
+
+    with tab6:
         render_case_notes_section(case_id, user_id)
 
     st.markdown("---")

--- a/scheduler.py
+++ b/scheduler.py
@@ -85,6 +85,7 @@ from db import (
     get_prefs_by_user_ids,
     UserPreference,
 )
+from db.crud.knowledge import process_due_knowledge_invalidations
 from notifications.reminder_engine import (
     plan_eligible_reminders,
     should_process_threshold,
@@ -106,6 +107,8 @@ _instance_id = str(uuid.uuid4())[:8]
 # Lock configuration
 LOCK_KEY = "legalassist:scheduler:lock"
 LOCK_TTL_SECONDS = 55 * 60  # 55 minutes to allow hourly job to complete
+KNOWLEDGE_LOCK_KEY = "legalassist:knowledge:lock"
+KNOWLEDGE_LOCK_TTL_SECONDS = 10 * 60
 
 
 def _get_redis_client():
@@ -307,6 +310,27 @@ def check_and_send_reminders():
             db.close()
 
 
+def recompute_due_knowledge_invalidations():
+    """Recompute stale knowledge artifacts after invalidations become due."""
+
+    lock_id = f"{_instance_id}:{os.getpid()}"
+    with distributed_lock(KNOWLEDGE_LOCK_KEY, KNOWLEDGE_LOCK_TTL_SECONDS, lock_id) as has_lock:
+        if not has_lock:
+            logger.debug("Skipping knowledge recompute - another instance holds the lock")
+            return
+
+        init_db()
+
+        db = SessionLocal()
+        try:
+            processed = process_due_knowledge_invalidations(db)
+            logger.info("Knowledge recompute job completed", processed=len(processed))
+        except Exception as exc:
+            logger.error(f"Error in knowledge recompute job: {exc}", exc_info=True)
+        finally:
+            db.close()
+
+
 def setup_scheduler(scheduler_class):
     """
     ============================================================================
@@ -400,6 +424,14 @@ def setup_scheduler(scheduler_class):
             name="Hourly Deadline Reminder Check",
             replace_existing=True
         )
+
+        scheduler.add_job(
+            recompute_due_knowledge_invalidations,
+            trigger=CronTrigger(minute="*/15", second=10),
+            id="knowledge_recompute_job",
+            name="Quarter-Hour Knowledge Recompute",
+            replace_existing=True,
+        )
         
         logger.info(f"Successfully configured {scheduler_class.__name__}")
         logger.info("Job store: SQLAlchemy (Persistent)")
@@ -454,6 +486,12 @@ def trigger_reminder_check_now():
     """
     logger.info("Manually triggering reminder check...")
     check_and_send_reminders()
+
+
+def trigger_knowledge_recompute_now():
+    """Manually trigger the knowledge recompute job (useful for testing/debugging)."""
+    logger.info("Manually triggering knowledge recompute...")
+    recompute_due_knowledge_invalidations()
 
 
 def run_worker():

--- a/tests/test_knowledge_invalidation.py
+++ b/tests/test_knowledge_invalidation.py
@@ -1,0 +1,128 @@
+"""Tests for knowledge invalidation persistence and recompute tracking."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from db.base import Base
+from db.models import Case, CaseStatus, DocumentType, KnowledgeInvalidationStatus, User
+from db.case_service import create_case_document, update_case_document
+from db.crud.knowledge import (
+    list_knowledge_invalidations,
+    process_due_knowledge_invalidations,
+    record_knowledge_invalidation,
+)
+
+
+@pytest.fixture
+def test_db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db = TestingSessionLocal()
+    yield db
+    db.close()
+
+
+def _create_user_and_case(db):
+    user = User(id=1, email="user@example.com")
+    db.add(user)
+    db.commit()
+
+    case = Case(
+        user_id=1,
+        case_number="CASE-100",
+        case_type="civil",
+        jurisdiction="Delhi",
+        status=CaseStatus.ACTIVE,
+        title="Test Case",
+    )
+    db.add(case)
+    db.commit()
+    db.refresh(case)
+    return user, case
+
+
+def test_create_case_document_records_document_created_invalidation(test_db):
+    _user, case = _create_user_and_case(test_db)
+
+    doc = create_case_document(
+        test_db,
+        case_id=case.id,
+        document_type=DocumentType.JUDGMENT,
+        user_id=1,
+        document_content="Initial judgment text",
+        summary="Initial summary",
+    )
+
+    rows = list_knowledge_invalidations(test_db, case_id=case.id)
+    assert len(rows) == 1
+
+    invalidation = rows[0]
+    assert invalidation.case_id == case.id
+    assert invalidation.document_id == doc.id
+    assert invalidation.reason == "document_created"
+    assert invalidation.scope_type == "case"
+    assert invalidation.scope_value == f"case:{case.id}"
+    assert invalidation.status == KnowledgeInvalidationStatus.PENDING.value
+    assert invalidation.details["document_type"] == DocumentType.JUDGMENT.value
+    assert "changed_fields" in invalidation.details
+
+
+def test_update_case_document_tracks_reason_and_changed_fields(test_db):
+    _user, case = _create_user_and_case(test_db)
+
+    doc = create_case_document(
+        test_db,
+        case_id=case.id,
+        document_type=DocumentType.JUDGMENT,
+        user_id=1,
+        document_content="Initial judgment text",
+        summary="Initial summary",
+    )
+
+    updated = update_case_document(
+        test_db,
+        document_id=doc.id,
+        summary="Updated summary",
+        ocr_used=True,
+    )
+
+    assert updated is not None
+
+    rows = list_knowledge_invalidations(test_db, case_id=case.id)
+    assert len(rows) == 2
+
+    latest = rows[0]
+    assert latest.reason == "summary_updated"
+    assert latest.details["changed_fields"] == ["summary", "ocr_used"]
+    assert latest.document_id == doc.id
+    assert latest.status == KnowledgeInvalidationStatus.PENDING.value
+
+
+def test_due_knowledge_invalidations_are_processed(test_db):
+    _user, case = _create_user_and_case(test_db)
+
+    record_knowledge_invalidation(
+        test_db,
+        scope_type="case",
+        case_id=case.id,
+        user_id=1,
+        reason="manual_refresh",
+        scheduled_for=datetime.now(timezone.utc) - timedelta(minutes=5),
+        details={"changed_fields": ["summary"]},
+    )
+
+    processed = process_due_knowledge_invalidations(
+        test_db,
+        recompute_handler=lambda db, invalidation: True,
+    )
+
+    assert len(processed) == 1
+    refreshed = list_knowledge_invalidations(test_db, case_id=case.id)[0]
+    assert refreshed.status == KnowledgeInvalidationStatus.COMPLETED.value
+    assert refreshed.recompute_attempts == 1
+    assert refreshed.recompute_started_at is not None
+    assert refreshed.recompute_completed_at is not None


### PR DESCRIPTION
Implemented the freshness/invalidation flow end to end. The persisted ledger is in knowledge.py, the record/query/recompute logic is in knowledge.py, and document writes now emit invalidations from case_service.py and case_service.py. The API endpoint is knowledge.py, the periodic recompute job is wired in scheduler.py and scheduled in scheduler.py, and the Case Details page now shows a Knowledge Status tab in 2_Case_Details.py and 2_Case_Details.py.

I also added focused tests in test_knowledge_invalidation.py, test_knowledge_invalidation.py, and test_knowledge_invalidation.py. Validation passed: `pytest test_knowledge_invalidation.py -q` returned 3 passed.

closes #733