### PR TITLE
Feature Flag + A/B Testing Framework (User-Scoped)

### DIFF
--- a/api/feature_flags.py
+++ b/api/feature_flags.py
@@ -3,9 +3,14 @@ Feature flag manager with optional Redis backend and env overrides.
 """
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+import hashlib
+import json
 import os
-from typing import Optional, Dict
+from typing import Optional, Dict, Any, Iterable, Mapping
 import structlog
+
+from observability.instrumentation import record_feature_flag_event
 
 try:
     import redis
@@ -13,6 +18,45 @@ except Exception:  # pragma: no cover
     redis = None
 
 logger = structlog.get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class FeatureFlagDefinition:
+    """Configuration schema for a feature flag rollout."""
+
+    name: str
+    rollout_percent: int = 100
+    targeting_rules: Dict[str, Any] = field(default_factory=dict)
+    enabled: Optional[bool] = None
+
+    def __post_init__(self):
+        normalized_name = self.name.upper().strip()
+        if not normalized_name:
+            raise ValueError("Feature flag name cannot be empty")
+        if self.rollout_percent < 0 or self.rollout_percent > 100:
+            raise ValueError("rollout_percent must be between 0 and 100")
+        object.__setattr__(self, "name", normalized_name)
+
+
+DEFAULT_FEATURE_FLAG_DEFINITIONS = [
+    FeatureFlagDefinition(
+        name="knowledge_status_dashboard",
+        rollout_percent=int(os.getenv("FEATURE_KNOWLEDGE_STATUS_DASHBOARD_ROLLOUT", "10")),
+        targeting_rules={},
+    ),
+]
+
+
+def _normalize_flag_name(name: str) -> str:
+    return str(name or "").upper().strip()
+
+
+def _coerce_target_list(value: Any) -> set[str]:
+    if value is None:
+        return set()
+    if isinstance(value, (list, tuple, set)):
+        return {str(item) for item in value}
+    return {str(value)}
 
 
 class FeatureFlagManager:
@@ -24,10 +68,19 @@ class FeatureFlagManager:
       3. Default values provided at init
     """
 
-    def __init__(self, defaults: Optional[Dict[str, bool]] = None, redis_url: Optional[str] = None):
+    def __init__(
+        self,
+        defaults: Optional[Dict[str, bool]] = None,
+        redis_url: Optional[str] = None,
+        definitions: Optional[Iterable[FeatureFlagDefinition | Mapping[str, Any]]] = None,
+    ):
         self.defaults = defaults or {}
         self.redis_url = redis_url or os.getenv("REDIS_URL")
         self._client = None
+        self.definitions: Dict[str, FeatureFlagDefinition] = {}
+
+        for definition in definitions or []:
+            self.register_flag_definition(definition)
 
     @property
     def client(self):
@@ -45,6 +98,114 @@ class FeatureFlagManager:
 
     def _redis_key(self, name: str) -> str:
         return f"feature:{name}"
+
+    def _redis_definition_key(self, name: str) -> str:
+        return f"feature:def:{name}"
+
+    def register_flag_definition(self, definition: FeatureFlagDefinition | Mapping[str, Any]) -> FeatureFlagDefinition:
+        if not isinstance(definition, FeatureFlagDefinition):
+            definition = FeatureFlagDefinition(**dict(definition))
+        self.definitions[definition.name] = definition
+        client = self.client
+        if client:
+            try:
+                client.set(self._redis_definition_key(definition.name), json.dumps({
+                    "name": definition.name,
+                    "rollout_percent": definition.rollout_percent,
+                    "targeting_rules": definition.targeting_rules,
+                    "enabled": definition.enabled,
+                }))
+            except Exception as e:
+                logger.warning("feature_flags_definition_persist_failed", name=definition.name, error=str(e))
+        return definition
+
+    def get_flag_definition(self, name: str) -> Optional[FeatureFlagDefinition]:
+        name_up = _normalize_flag_name(name)
+        if name_up in self.definitions:
+            return self.definitions[name_up]
+
+        client = self.client
+        if client:
+            try:
+                raw = client.get(self._redis_definition_key(name_up))
+                if raw:
+                    payload = json.loads(raw)
+                    definition = FeatureFlagDefinition(**payload)
+                    self.definitions[name_up] = definition
+                    return definition
+            except Exception as e:
+                logger.warning("feature_flags_definition_load_failed", name=name_up, error=str(e))
+        return None
+
+    def _deterministic_bucket(self, name: str, user_id: str, salt: str = "") -> int:
+        payload = f"{_normalize_flag_name(name)}:{user_id}:{salt}".encode("utf-8")
+        digest = hashlib.sha256(payload).hexdigest()
+        return int(digest[:8], 16) % 100
+
+    def _matches_targeting_rules(self, rules: Dict[str, Any], *, user_id: Optional[str], attributes: Optional[Dict[str, Any]]) -> bool:
+        if not rules:
+            return True
+
+        attributes = attributes or {}
+        user_id_str = str(user_id) if user_id is not None else None
+
+        include_user_ids = _coerce_target_list(rules.get("user_ids") or rules.get("include_user_ids"))
+        exclude_user_ids = _coerce_target_list(rules.get("exclude_user_ids") or rules.get("deny_user_ids"))
+        roles = _coerce_target_list(rules.get("roles"))
+        include_emails = _coerce_target_list(rules.get("emails") or rules.get("include_emails"))
+
+        if include_user_ids and user_id_str not in include_user_ids:
+            return False
+        if user_id_str and user_id_str in exclude_user_ids:
+            return False
+
+        if roles:
+            role = str(attributes.get("role", ""))
+            if role not in roles:
+                return False
+
+        if include_emails:
+            email = str(attributes.get("email", ""))
+            if email not in include_emails:
+                return False
+
+        attribute_rules = rules.get("attributes") or {}
+        for key, expected in attribute_rules.items():
+            actual = attributes.get(key)
+            if isinstance(expected, dict):
+                if "equals" in expected and actual != expected["equals"]:
+                    return False
+                if "in" in expected and actual not in set(expected["in"]):
+                    return False
+                if "not_in" in expected and actual in set(expected["not_in"]):
+                    return False
+            elif actual != expected:
+                return False
+
+        return True
+
+    def _evaluate_definition(
+        self,
+        definition: FeatureFlagDefinition,
+        *,
+        user_id: Optional[str],
+        attributes: Optional[Dict[str, Any]] = None,
+    ) -> tuple[bool, int, str]:
+        attributes = attributes or {}
+
+        if definition.enabled is not None:
+            enabled = bool(definition.enabled)
+            return enabled, 0 if enabled else 100, "forced_on" if enabled else "forced_off"
+
+        if not self._matches_targeting_rules(definition.targeting_rules, user_id=user_id, attributes=attributes):
+            return False, 100, "targeting_excluded"
+
+        if user_id is None:
+            return bool(self.defaults.get(definition.name, False)), 0, "anonymous"
+
+        salt = str(definition.targeting_rules.get("salt", ""))
+        bucket = self._deterministic_bucket(definition.name, user_id, salt=salt)
+        return bucket < definition.rollout_percent, bucket, f"bucket_{bucket:02d}"
 
     def is_enabled(self, name: str) -> bool:
         name_up = name.upper()
@@ -67,6 +228,39 @@ class FeatureFlagManager:
         # 3) Defaults
         return bool(self.defaults.get(name_up, False))
 
+    def is_enabled_for_user(
+        self,
+        name: str,
+        user_id: Optional[str],
+        *,
+        attributes: Optional[Dict[str, Any]] = None,
+        surface: str = "api",
+        record_event: bool = True,
+    ) -> bool:
+        name_up = _normalize_flag_name(name)
+        definition = self.get_flag_definition(name_up)
+
+        if definition is None:
+            enabled = self.is_enabled(name_up)
+            if record_event and user_id is not None:
+                record_feature_flag_event("flag_shown", name_up, surface=surface, variant="default_enabled" if enabled else "default_disabled")
+            return enabled
+
+        enabled, _bucket, variant = self._evaluate_definition(definition, user_id=user_id, attributes=attributes)
+        if record_event:
+            record_feature_flag_event("flag_shown", name_up, surface=surface, variant=variant)
+        return enabled
+
+    def mark_flag_used(
+        self,
+        name: str,
+        *,
+        user_id: Optional[str] = None,
+        surface: str = "api",
+        variant: str = "used",
+    ) -> None:
+        record_feature_flag_event("flag_used", _normalize_flag_name(name), surface=surface, variant=variant)
+
     def set_flag(self, name: str, enabled: bool) -> bool:
         name_up = name.upper()
         client = self.client
@@ -88,5 +282,20 @@ _manager: Optional[FeatureFlagManager] = None
 def get_feature_flag_manager(defaults: Optional[Dict[str, bool]] = None) -> FeatureFlagManager:
     global _manager
     if _manager is None:
-        _manager = FeatureFlagManager(defaults=defaults)
+        _manager = FeatureFlagManager(defaults=defaults, definitions=DEFAULT_FEATURE_FLAG_DEFINITIONS)
     return _manager
+
+
+def is_feature_enabled_for_user(
+    name: str,
+    user_id: Optional[str],
+    *,
+    attributes: Optional[Dict[str, Any]] = None,
+    surface: str = "api",
+) -> bool:
+    return get_feature_flag_manager().is_enabled_for_user(
+        name,
+        user_id,
+        attributes=attributes,
+        surface=surface,
+    )

--- a/api/idempotency.py
+++ b/api/idempotency.py
@@ -3,6 +3,8 @@ Redis-backed idempotency manager for Celery tasks.
 """
 from __future__ import annotations
 
+import base64
+import hashlib
 import os
 import json
 import time
@@ -49,6 +51,24 @@ class IdempotencyManager:
 
     def _key_result(self, key: str) -> str:
         return f"idemp:result:{key}"
+
+    def _key_http_result(self, key: str) -> str:
+        return f"idemp:http:result:{key}"
+
+    def _key_http_lock(self, key: str) -> str:
+        return f"idemp:http:lock:{key}"
+
+    @staticmethod
+    def build_http_key(
+        *,
+        method: str,
+        path: str,
+        idempotency_key: str,
+        principal: str,
+        body: bytes,
+    ) -> str:
+        principal_hash = hashlib.sha256(principal.encode("utf-8")).hexdigest()
+        return f"{method.upper()}:{path}:{principal_hash}:{idempotency_key}"
 
     def acquire(self, key: str, ttl: int = 60) -> bool:
         """Acquire a lock for the given idempotency key. Returns True if acquired."""
@@ -97,5 +117,72 @@ class IdempotencyManager:
     def release_lock(self, key: str) -> None:
         try:
             self.client.delete(self._key_lock(key))
+        except Exception:
+            pass
+
+    def acquire_http(self, key: str, ttl: int = 3600) -> bool:
+        """Acquire a lock for a HTTP idempotency key."""
+        lock_key = self._key_http_lock(key)
+        try:
+            acquired = self.client.set(lock_key, b"1", nx=True, ex=ttl)
+            if acquired:
+                logger.info("http_idempotency_lock_acquired", key=key)
+            else:
+                logger.info("http_idempotency_lock_exists", key=key)
+            return bool(acquired)
+        except Exception as e:
+            logger.error("http_idempotency_acquire_failed", key=key, error=str(e))
+            return True
+
+    def store_http_response(
+        self,
+        key: str,
+        response: dict,
+        ttl: int = 86400,
+    ) -> None:
+        """Persist the serialized HTTP response for replay on retry."""
+        payload = {
+            "response": {
+                "status_code": int(response.get("status_code", 200)),
+                "headers": response.get("headers", {}),
+                "body_b64": base64.b64encode(response.get("body", b"")).decode("ascii"),
+                "media_type": response.get("media_type"),
+            },
+            "request_fingerprint": response.get("request_fingerprint"),
+            "timestamp": int(time.time()),
+        }
+        try:
+            self.client.set(self._key_http_result(key), json.dumps(payload).encode("utf-8"), ex=ttl)
+            try:
+                self.client.delete(self._key_http_lock(key))
+            except Exception:
+                pass
+            logger.info("http_idempotency_response_stored", key=key)
+        except Exception as e:
+            logger.error("http_idempotency_store_failed", key=key, error=str(e))
+
+    def get_http_response(self, key: str) -> Optional[dict]:
+        """Return a stored HTTP response payload for the given key."""
+        try:
+            raw = self.client.get(self._key_http_result(key))
+            if not raw:
+                return None
+            data = json.loads(raw.decode("utf-8"))
+            response = data.get("response") or {}
+            body_b64 = response.get("body_b64") or ""
+            return {
+                "status_code": int(response.get("status_code", 200)),
+                "headers": response.get("headers", {}),
+                "body": base64.b64decode(body_b64.encode("ascii")) if body_b64 else b"",
+                "media_type": response.get("media_type"),
+                "request_fingerprint": data.get("request_fingerprint"),
+            }
+        except Exception as e:
+            logger.error("http_idempotency_get_failed", key=key, error=str(e))
+            return None
+
+    def release_http_lock(self, key: str) -> None:
+        try:
+            self.client.delete(self._key_http_lock(key))
         except Exception:
             pass

--- a/api/main.py
+++ b/api/main.py
@@ -34,7 +34,7 @@ from api.validation import (
 )
 
 # Import routes
-from api.routes import documents, cases, reports, analytics, deadlines, auth, health, case_search
+from api.routes import documents, cases, reports, analytics, deadlines, auth, health, case_search, knowledge
 from api.auth import get_current_user_optional
 
 settings = get_settings()
@@ -131,6 +131,7 @@ def create_app() -> FastAPI:
     app.include_router(deadlines.router)
     app.include_router(auth.router)
     app.include_router(case_search.router)  # Case search and precedent matching
+    app.include_router(knowledge.router)
     # Model feedback & optimization
     from api.routes import models as models_router
     app.include_router(models_router.router)

--- a/api/main.py
+++ b/api/main.py
@@ -21,7 +21,8 @@ from api.middleware import (
     add_correlation_id_middleware,
     error_handling_middleware,
     logging_middleware,
-    request_size_limit_middleware
+    request_size_limit_middleware,
+    idempotency_middleware,
 )
 from api.csrf import CSRFProtectionMiddleware
 from api.limiter import cleanup_limiter
@@ -112,6 +113,7 @@ def create_app() -> FastAPI:
     
     # Add middleware
     app.middleware("http")(request_size_limit_middleware)
+    app.middleware("http")(idempotency_middleware)
     app.middleware("http")(add_correlation_id_middleware)
     app.middleware("http")(logging_middleware)
     app.middleware("http")(error_handling_middleware)

--- a/api/middleware.py
+++ b/api/middleware.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import time
 from typing import Callable
 
 import structlog
 from fastapi import HTTPException, Request, status
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 
 from api.config import get_settings
+from api.idempotency import IdempotencyManager
 from api.limiter import (
     build_rate_limit_response,
     get_rate_limit_policy,
@@ -30,6 +33,7 @@ from observability.instrumentation import (
 
 settings = get_settings()
 logger = structlog.get_logger(__name__)
+http_idempotency_manager = IdempotencyManager()
 
 SKIP_PATHS = {"/api/v1/health", "/api/v1/health/ready", "/api/v1/health/live", "/metrics", "/"}
 UPLOAD_PATH_PREFIXES = (
@@ -40,6 +44,122 @@ UPLOAD_PATH_PREFIXES = (
 ANALYTICS_PATH_PREFIXES = (
     "/api/v1/analytics",
 )
+IDEMPOTENT_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+
+
+def _request_principal(request: Request) -> str:
+    auth_header = request.headers.get("authorization")
+    if auth_header:
+        return auth_header
+    api_key = request.headers.get("x-api-key")
+    if api_key:
+        return api_key
+    user_id = request.headers.get("x-user-id")
+    if user_id:
+        return user_id
+    return "anonymous"
+
+
+def _idempotency_exempt_path(path: str) -> bool:
+    return path in SKIP_PATHS or path in {"/openapi.json", "/docs", "/redoc"}
+
+
+def _response_headers_for_cache(response: Response) -> dict:
+    headers = {}
+    for key, value in response.headers.items():
+        lower_key = key.lower()
+        if lower_key in {"content-length", "transfer-encoding", "connection", "date", "server"}:
+            continue
+        headers[key] = value
+    return headers
+
+
+async def idempotency_middleware(request: Request, call_next: Callable):
+    """Replay successful write responses when the client retries with the same key."""
+
+    if request.method.upper() not in IDEMPOTENT_METHODS or _idempotency_exempt_path(request.url.path):
+        return await call_next(request)
+
+    idempotency_key = request.headers.get("Idempotency-Key")
+    if not idempotency_key:
+        return JSONResponse(
+            status_code=status.HTTP_428_PRECONDITION_REQUIRED,
+            content={
+                "error_code": "IDEMPOTENCY_KEY_REQUIRED",
+                "message": "Idempotency-Key header is required for write operations.",
+            },
+        )
+
+    body = await request.body()
+    body_fingerprint = hashlib.sha256(body or b"").hexdigest()
+    key = http_idempotency_manager.build_http_key(
+        method=request.method,
+        path=request.url.path,
+        idempotency_key=idempotency_key,
+        principal=_request_principal(request),
+        body=body,
+    )
+
+    cached = http_idempotency_manager.get_http_response(key)
+    if cached:
+        if cached.get("request_fingerprint") and cached["request_fingerprint"] != body_fingerprint:
+            return JSONResponse(
+                status_code=status.HTTP_409_CONFLICT,
+                content={
+                    "error_code": "IDEMPOTENCY_KEY_REUSED",
+                    "message": "This Idempotency-Key was already used with a different request body.",
+                },
+            )
+        return Response(
+            content=cached["body"],
+            status_code=cached["status_code"],
+            headers={**cached["headers"], "X-Idempotent-Replay": "true"},
+            media_type=cached.get("media_type") or cached["headers"].get("content-type"),
+        )
+
+    if not http_idempotency_manager.acquire_http(key, ttl=86400):
+        cached = http_idempotency_manager.get_http_response(key)
+        if cached:
+            return Response(
+                content=cached["body"],
+                status_code=cached["status_code"],
+                headers={**cached["headers"], "X-Idempotent-Replay": "true"},
+                media_type=cached.get("media_type") or cached["headers"].get("content-type"),
+            )
+        return JSONResponse(
+            status_code=status.HTTP_409_CONFLICT,
+            content={
+                "error_code": "IDEMPOTENCY_IN_PROGRESS",
+                "message": "A request with this idempotency key is already in progress.",
+            },
+        )
+
+    response = await call_next(request)
+
+    response_body = b""
+    async for chunk in response.body_iterator:
+        response_body += chunk
+
+    headers = _response_headers_for_cache(response)
+    cache_payload = {
+        "status_code": response.status_code,
+        "headers": headers,
+        "body": response_body,
+        "media_type": response.media_type or headers.get("content-type"),
+        "request_fingerprint": body_fingerprint,
+    }
+
+    if response.status_code < 400:
+        http_idempotency_manager.store_http_response(key, cache_payload, ttl=86400)
+    else:
+        http_idempotency_manager.release_http_lock(key)
+
+    return Response(
+        content=response_body,
+        status_code=response.status_code,
+        headers=headers,
+        media_type=response.media_type or headers.get("content-type"),
+    )
 
 
 async def rate_limit_middleware(request: Request, call_next: Callable):

--- a/api/models.py
+++ b/api/models.py
@@ -345,6 +345,37 @@ class UpcomingDeadlinesResponse(BaseModel):
 
 
 # ============================================================================
+# Knowledge Freshness Models
+# ============================================================================
+
+class KnowledgeInvalidationItem(BaseModel):
+    id: int
+    user_id: Optional[int] = None
+    case_id: Optional[int] = None
+    document_id: Optional[int] = None
+    scope_type: str
+    scope_value: str
+    reason: str
+    details: Optional[Dict[str, Any]] = None
+    status: str
+    invalidated_at: datetime
+    scheduled_for: Optional[datetime] = None
+    recompute_started_at: Optional[datetime] = None
+    recompute_completed_at: Optional[datetime] = None
+    error_message: Optional[str] = None
+    recompute_attempts: int = 0
+
+
+class KnowledgeInvalidationListResponse(BaseModel):
+    items: List[KnowledgeInvalidationItem]
+    total: int
+    stale_count: int
+    fresh_count: int
+    next_recompute_at: Optional[datetime] = None
+    generated_at: datetime
+
+
+# ============================================================================
 # User Models
 # ============================================================================
 

--- a/api/routes/knowledge.py
+++ b/api/routes/knowledge.py
@@ -1,0 +1,74 @@
+"""Knowledge freshness and invalidation endpoints."""
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from api.auth import CurrentUser, get_current_user
+from api.models import KnowledgeInvalidationItem, KnowledgeInvalidationListResponse
+from db.crud.knowledge import get_knowledge_freshness_summary, list_knowledge_invalidations
+from database import get_db
+
+
+router = APIRouter(prefix="/api/v1/knowledge", tags=["knowledge"])
+
+
+@router.get("/invalidations", response_model=KnowledgeInvalidationListResponse, summary="List knowledge invalidations")
+async def list_invalidations(
+    case_id: int | None = Query(default=None),
+    document_id: int | None = Query(default=None),
+    status: str | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=200),
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> KnowledgeInvalidationListResponse:
+    """Return the invalidation ledger for the current user.
+
+    Admin users can still see their own invalidations; this endpoint keeps the
+    initial scope user-centric and can be expanded later with org-level filters.
+    """
+
+    rows = list_knowledge_invalidations(
+        db,
+        user_id=current_user.user_id if current_user.role != "admin" else None,
+        case_id=case_id,
+        document_id=document_id,
+        status=status,
+        limit=limit,
+    )
+    summary = get_knowledge_freshness_summary(
+        db,
+        user_id=current_user.user_id if current_user.role != "admin" else None,
+        case_id=case_id,
+    )
+
+    items = [
+        KnowledgeInvalidationItem(
+            id=row.id,
+            user_id=row.user_id,
+            case_id=row.case_id,
+            document_id=row.document_id,
+            scope_type=row.scope_type,
+            scope_value=row.scope_value,
+            reason=row.reason,
+            details=row.details,
+            status=row.status,
+            invalidated_at=row.invalidated_at,
+            scheduled_for=row.scheduled_for,
+            recompute_started_at=row.recompute_started_at,
+            recompute_completed_at=row.recompute_completed_at,
+            error_message=row.error_message,
+            recompute_attempts=row.recompute_attempts,
+        )
+        for row in rows
+    ]
+
+    return KnowledgeInvalidationListResponse(
+        items=items,
+        total=summary["total"],
+        stale_count=summary["stale"],
+        fresh_count=summary["fresh"],
+        next_recompute_at=summary["next_recompute_at"],
+        generated_at=datetime.now(timezone.utc),
+    )

--- a/api/routes/knowledge.py
+++ b/api/routes/knowledge.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from api.auth import CurrentUser, get_current_user
+from api.feature_flags import is_feature_enabled_for_user, get_feature_flag_manager
 from api.models import KnowledgeInvalidationItem, KnowledgeInvalidationListResponse
 from db.crud.knowledge import get_knowledge_freshness_summary, list_knowledge_invalidations
 from database import get_db
@@ -28,6 +29,29 @@ async def list_invalidations(
     Admin users can still see their own invalidations; this endpoint keeps the
     initial scope user-centric and can be expanded later with org-level filters.
     """
+
+    feature_enabled = is_feature_enabled_for_user(
+        "knowledge_status_dashboard",
+        str(current_user.user_id),
+        attributes={"role": current_user.role, "email": current_user.email},
+        surface="api",
+    )
+
+    if not feature_enabled:
+        return KnowledgeInvalidationListResponse(
+            items=[],
+            total=0,
+            stale_count=0,
+            fresh_count=0,
+            next_recompute_at=None,
+            generated_at=datetime.now(timezone.utc),
+        )
+
+    get_feature_flag_manager().mark_flag_used(
+        "knowledge_status_dashboard",
+        user_id=str(current_user.user_id),
+        surface="api",
+    )
 
     rows = list_knowledge_invalidations(
         db,

--- a/database.py
+++ b/database.py
@@ -54,6 +54,12 @@ from db.crud.notifications import (
     has_notification_been_sent,
     log_notification,
 )
+from db.crud.knowledge import (
+    record_knowledge_invalidation,
+    list_knowledge_invalidations,
+    get_knowledge_freshness_summary,
+    process_due_knowledge_invalidations,
+)
 from db.models import (
     Attachment,
     Case,
@@ -71,6 +77,8 @@ from db.models import (
     CaseNoteVersion,
     DocumentType,
     KnowledgeGraphEdge,
+    KnowledgeInvalidation,
+    KnowledgeInvalidationStatus,
     ModelFeedback,
     ModelPerformance,
     ModelRoutingRule,
@@ -146,6 +154,8 @@ __all__ = [
     "CaseArgument",
     "KnowledgeGraphEdge",
     "PrecedentMatch",
+    "KnowledgeInvalidation",
+    "KnowledgeInvalidationStatus",
     "Report",
     "create_case_deadline",
     "get_upcoming_deadlines",
@@ -200,6 +210,10 @@ __all__ = [
     "submit_similarity_feedback",
     "get_similarity_feedback",
     "aggregate_model_performance",
+    "record_knowledge_invalidation",
+    "list_knowledge_invalidations",
+    "get_knowledge_freshness_summary",
+    "process_due_knowledge_invalidations",
 ]
 
 

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -22,6 +22,12 @@ from .crud.notifications import (
     log_notification,
     get_notification_history,
 )
+from .crud.knowledge import (
+    record_knowledge_invalidation,
+    list_knowledge_invalidations,
+    get_knowledge_freshness_summary,
+    process_due_knowledge_invalidations,
+)
 from .crud.feedback import submit_user_feedback, get_user_feedback
 
 __all__ = [
@@ -51,4 +57,8 @@ __all__ = [
     "get_notification_history",
     "submit_user_feedback",
     "get_user_feedback",
+    "record_knowledge_invalidation",
+    "list_knowledge_invalidations",
+    "get_knowledge_freshness_summary",
+    "process_due_knowledge_invalidations",
 ]

--- a/db/case_service.py
+++ b/db/case_service.py
@@ -18,6 +18,7 @@ from db.models import (
     ModelFeedback,
     UserFeedback,
 )
+from db.crud.knowledge import record_knowledge_invalidation
 
 
 def create_case(db: Session, user_id: int, case_number: str, case_type: str, jurisdiction: str, title: Optional[str] = None) -> Case:
@@ -103,6 +104,20 @@ def create_case_document(
     db.add(doc)
     db.commit()
     db.refresh(doc)
+
+    record_knowledge_invalidation(
+        db,
+        scope_type="case",
+        case_id=case_id,
+        document_id=doc.id,
+        user_id=user_id,
+        reason="document_created",
+        details={
+            "document_type": getattr(document_type, "value", document_type),
+            "source_attachment_id": source_attachment_id,
+            "changed_fields": ["document_content", "summary", "remedies", "extracted_metadata"],
+        },
+    )
     return doc
 
 
@@ -236,21 +251,42 @@ def update_case_document(
     """Update case document"""
     doc = db.query(CaseDocument).filter(CaseDocument.id == document_id).first()
     if doc:
+        changed_fields = []
         if document_content is not None:
             doc.document_content = document_content
+            changed_fields.append("document_content")
         if summary is not None:
             doc.summary = summary
+            changed_fields.append("summary")
         if remedies is not None:
             doc.remedies = remedies
+            changed_fields.append("remedies")
         if extracted_metadata is not None:
             doc.extracted_metadata = extracted_metadata
+            changed_fields.append("extracted_metadata")
         if extraction_method is not None:
             doc.extraction_method = extraction_method
+            changed_fields.append("extraction_method")
         if ocr_used is not None:
             doc.ocr_used = ocr_used
+            changed_fields.append("ocr_used")
         try:
             db.commit()
             db.refresh(doc)
+            if changed_fields:
+                reason = f"{changed_fields[0]}_updated"
+                record_knowledge_invalidation(
+                    db,
+                    scope_type="case",
+                    case_id=doc.case_id,
+                    document_id=doc.id,
+                    reason=reason,
+                    details={
+                        "changed_fields": changed_fields,
+                        "document_id": doc.id,
+                        "case_id": doc.case_id,
+                    },
+                )
         except Exception as e:
             db.rollback()
             raise RuntimeError(f"Database write failed for case document {document_id}: {str(e)}") from e

--- a/db/crud/__init__.py
+++ b/db/crud/__init__.py
@@ -8,6 +8,12 @@ from .reports import (
     list_reports_by_user,
     list_reports_by_case,
 )
+from .knowledge import (
+    record_knowledge_invalidation,
+    list_knowledge_invalidations,
+    get_knowledge_freshness_summary,
+    process_due_knowledge_invalidations,
+)
 
 __all__ = [
     "create_report",
@@ -16,5 +22,9 @@ __all__ = [
     "update_report_status",
     "list_reports_by_user",
     "list_reports_by_case",
+    "record_knowledge_invalidation",
+    "list_knowledge_invalidations",
+    "get_knowledge_freshness_summary",
+    "process_due_knowledge_invalidations",
 ]
 

--- a/db/crud/knowledge.py
+++ b/db/crud/knowledge.py
@@ -1,0 +1,192 @@
+import datetime as dt
+from typing import Any, Callable, Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+from db.models import (
+    Case,
+    CaseDocument,
+    KnowledgeInvalidation,
+    KnowledgeInvalidationStatus,
+)
+
+
+def _utcnow() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def _scope_value(scope_type: str, case_id: Optional[int], document_id: Optional[int], explicit_scope_value: Optional[str]) -> str:
+    if explicit_scope_value:
+        return explicit_scope_value
+    if scope_type == "document" and document_id is not None:
+        return f"document:{document_id}"
+    if case_id is not None:
+        return f"case:{case_id}"
+    return scope_type
+
+
+def record_knowledge_invalidation(
+    db: Session,
+    *,
+    scope_type: str,
+    reason: str,
+    case_id: Optional[int] = None,
+    document_id: Optional[int] = None,
+    user_id: Optional[int] = None,
+    scope_value: Optional[str] = None,
+    details: Optional[Dict[str, Any]] = None,
+    scheduled_for: Optional[dt.datetime] = None,
+) -> KnowledgeInvalidation:
+    invalidation = KnowledgeInvalidation(
+        user_id=user_id,
+        case_id=case_id,
+        document_id=document_id,
+        scope_type=scope_type,
+        scope_value=_scope_value(scope_type, case_id, document_id, scope_value),
+        reason=reason,
+        details=details or {},
+        status=KnowledgeInvalidationStatus.PENDING.value,
+        invalidated_at=_utcnow(),
+        scheduled_for=scheduled_for or _utcnow(),
+    )
+    db.add(invalidation)
+    db.commit()
+    db.refresh(invalidation)
+    return invalidation
+
+
+def list_knowledge_invalidations(
+    db: Session,
+    *,
+    user_id: Optional[int] = None,
+    case_id: Optional[int] = None,
+    document_id: Optional[int] = None,
+    status: Optional[str] = None,
+    limit: int = 50,
+) -> List[KnowledgeInvalidation]:
+    query = db.query(KnowledgeInvalidation)
+
+    if user_id is not None:
+        query = query.filter(KnowledgeInvalidation.user_id == user_id)
+    if case_id is not None:
+        query = query.filter(KnowledgeInvalidation.case_id == case_id)
+    if document_id is not None:
+        query = query.filter(KnowledgeInvalidation.document_id == document_id)
+    if status is not None:
+        query = query.filter(KnowledgeInvalidation.status == status)
+
+    return (
+        query.order_by(KnowledgeInvalidation.invalidated_at.desc())
+        .limit(limit)
+        .all()
+    )
+
+
+def get_knowledge_freshness_summary(
+    db: Session,
+    *,
+    user_id: Optional[int] = None,
+    case_id: Optional[int] = None,
+) -> Dict[str, Any]:
+    query = db.query(KnowledgeInvalidation)
+    if user_id is not None:
+        query = query.filter(KnowledgeInvalidation.user_id == user_id)
+    if case_id is not None:
+        query = query.filter(KnowledgeInvalidation.case_id == case_id)
+
+    rows = query.all()
+    stale_rows = [row for row in rows if row.status != KnowledgeInvalidationStatus.COMPLETED.value]
+    next_recompute_at = None
+    if stale_rows:
+        scheduled_times = [row.scheduled_for for row in stale_rows if row.scheduled_for]
+        if scheduled_times:
+            next_recompute_at = min(scheduled_times)
+
+    latest = max(rows, key=lambda row: row.invalidated_at, default=None)
+    return {
+        "total": len(rows),
+        "stale": len(stale_rows),
+        "fresh": len(rows) - len(stale_rows),
+        "next_recompute_at": next_recompute_at,
+        "latest": latest,
+    }
+
+
+def _recompute_case_scope(db: Session, invalidation: KnowledgeInvalidation) -> bool:
+    case_id = invalidation.case_id
+    document_id = invalidation.document_id
+
+    if case_id is None and document_id is None and invalidation.scope_value.startswith("case:"):
+        try:
+            case_id = int(invalidation.scope_value.split(":", 1)[1])
+        except (TypeError, ValueError):
+            case_id = None
+
+    if document_id is not None and case_id is None:
+        document = db.query(CaseDocument).filter(CaseDocument.id == document_id).first()
+        if document:
+            case_id = document.case_id
+
+    if case_id is None:
+        return True
+
+    from core.embedding_engine import EmbeddingEngine
+
+    engine = EmbeddingEngine()
+    if document_id is not None:
+        return engine.embed_case(db, case_id=case_id, document_id=document_id, force_regenerate=True) is not None
+
+    return engine.embed_case(db, case_id=case_id, force_regenerate=True) is not None
+
+
+def process_due_knowledge_invalidations(
+    db: Session,
+    *,
+    now: Optional[dt.datetime] = None,
+    limit: int = 20,
+    recompute_handler: Optional[Callable[[Session, KnowledgeInvalidation], bool]] = None,
+) -> List[KnowledgeInvalidation]:
+    now = now or _utcnow()
+    recompute_handler = recompute_handler or _recompute_case_scope
+
+    pending = (
+        db.query(KnowledgeInvalidation)
+        .filter(
+            KnowledgeInvalidation.status.in_(
+                [
+                    KnowledgeInvalidationStatus.PENDING.value,
+                    KnowledgeInvalidationStatus.FAILED.value,
+                ]
+            ),
+            KnowledgeInvalidation.scheduled_for <= now,
+        )
+        .order_by(KnowledgeInvalidation.scheduled_for.asc(), KnowledgeInvalidation.invalidated_at.asc())
+        .limit(limit)
+        .all()
+    )
+
+    processed: List[KnowledgeInvalidation] = []
+    for invalidation in pending:
+        invalidation.status = KnowledgeInvalidationStatus.PROCESSING.value
+        invalidation.recompute_attempts += 1
+        invalidation.recompute_started_at = now
+        db.commit()
+        db.refresh(invalidation)
+
+        try:
+            recomputed = recompute_handler(db, invalidation)
+            if not recomputed:
+                raise RuntimeError("Recompute handler returned no result")
+
+            invalidation.status = KnowledgeInvalidationStatus.COMPLETED.value
+            invalidation.recompute_completed_at = _utcnow()
+            invalidation.error_message = None
+        except Exception as exc:
+            invalidation.status = KnowledgeInvalidationStatus.FAILED.value
+            invalidation.error_message = str(exc)
+        finally:
+            db.commit()
+            db.refresh(invalidation)
+            processed.append(invalidation)
+
+    return processed

--- a/db/models/__init__.py
+++ b/db/models/__init__.py
@@ -18,6 +18,7 @@ from .analytics import (
     KnowledgeGraphEdge,
     PrecedentMatch,
 )
+from .knowledge import KnowledgeInvalidation, KnowledgeInvalidationStatus
 
 __all__ = [
     "NotificationStatus",
@@ -55,5 +56,7 @@ __all__ = [
     "CaseArgument",
     "KnowledgeGraphEdge",
     "PrecedentMatch",
+    "KnowledgeInvalidation",
+    "KnowledgeInvalidationStatus",
 ]
 

--- a/db/models/knowledge.py
+++ b/db/models/knowledge.py
@@ -1,0 +1,49 @@
+import datetime as dt
+import enum
+
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Text, JSON, Index
+from sqlalchemy.orm import relationship
+
+from db.base import Base
+
+
+class KnowledgeInvalidationStatus(str, enum.Enum):
+    PENDING = "pending"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class KnowledgeInvalidation(Base):
+    __tablename__ = "knowledge_invalidations"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=True, index=True)
+    case_id = Column(Integer, ForeignKey("cases.id", ondelete="CASCADE"), nullable=True, index=True)
+    document_id = Column(Integer, ForeignKey("case_documents.id", ondelete="CASCADE"), nullable=True, index=True)
+    scope_type = Column(String(50), nullable=False, index=True)
+    scope_value = Column(String(255), nullable=False, index=True)
+    reason = Column(String(255), nullable=False, index=True)
+    details = Column(JSON, nullable=True)
+    status = Column(String(50), default=KnowledgeInvalidationStatus.PENDING.value, nullable=False, index=True)
+    invalidated_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), nullable=False, index=True)
+    scheduled_for = Column(DateTime(timezone=True), nullable=True, index=True)
+    recompute_started_at = Column(DateTime(timezone=True), nullable=True)
+    recompute_completed_at = Column(DateTime(timezone=True), nullable=True)
+    error_message = Column(Text, nullable=True)
+    recompute_attempts = Column(Integer, default=0, nullable=False)
+    updated_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), onupdate=lambda: dt.datetime.now(dt.timezone.utc))
+
+    user = relationship("User")
+    case = relationship("Case")
+    document = relationship("CaseDocument")
+
+    __table_args__ = (
+        Index("ix_knowledge_invalidations_scope", "scope_type", "scope_value", "status"),
+    )
+
+    def __repr__(self):
+        return (
+            f"<KnowledgeInvalidation(scope={self.scope_type}:{self.scope_value}, "
+            f"reason={self.reason}, status={self.status})>"
+        )

--- a/observability/instrumentation.py
+++ b/observability/instrumentation.py
@@ -244,6 +244,13 @@ api_errors_total = Counter(
     registry=registry
 )
 
+feature_flag_events_total = Counter(
+    'feature_flag_events_total',
+    'Feature flag lifecycle events',
+    ['event', 'flag_name', 'surface', 'variant'],
+    registry=registry
+)
+
 
 # ==================== Structured Logging ====================
 def setup_structured_logging():
@@ -586,6 +593,23 @@ def observe_business_metrics(*, active_cases_count: int | None = None, pending_d
         pending_deadlines.set(max(0, pending_deadlines_count))
     if active_users_count is not None:
         user_sessions_active.set(max(0, active_users_count))
+
+
+def record_feature_flag_event(event: str, flag_name: str, *, surface: str = "api", variant: str = "control"):
+    """Record feature flag exposure or usage for rollout analysis."""
+    feature_flag_events_total.labels(
+        event=event,
+        flag_name=flag_name,
+        surface=surface,
+        variant=variant,
+    ).inc()
+    log.info(
+        "feature_flag_event",
+        event=event,
+        flag_name=flag_name,
+        surface=surface,
+        variant=variant,
+    )
 
 
 # ==================== Metrics Endpoint ====================

--- a/pages/2_Case_Details.py
+++ b/pages/2_Case_Details.py
@@ -12,6 +12,7 @@ import routes
 from case_manager import get_case_detail, upload_case_document, mark_deadline_completed, mark_deadline_incomplete, add_manual_deadline, mark_case_appealed, mark_case_closed, mark_case_active, generate_case_summary_text
 from case_manager import upload_case_attachment, get_case_note_state, save_case_note, publish_case_note_for_case, get_case_note_history_for_case
 from core import extract_text_from_pdf
+from db.crud.knowledge import get_knowledge_freshness_summary, list_knowledge_invalidations
 from database import DocumentType, CaseStatus, SessionLocal, UserPreference
 import pytz
 import html
@@ -523,6 +524,61 @@ def render_remedies_section(remedies: Optional[Dict]):
                 st.write(span_text)
 
 
+def render_knowledge_status_section(case_id: int, user_id: int):
+    """Render the freshness dashboard for document-backed knowledge."""
+    st.subheader("📡 Knowledge Status")
+
+    db = SessionLocal()
+    try:
+        summary = get_knowledge_freshness_summary(db, user_id=user_id, case_id=case_id)
+        invalidations = list_knowledge_invalidations(db, user_id=user_id, case_id=case_id, limit=20)
+    finally:
+        db.close()
+
+    col1, col2, col3 = st.columns(3)
+    with col1:
+        st.metric("Fresh", summary["fresh"])
+    with col2:
+        st.metric("Stale", summary["stale"])
+    with col3:
+        next_run = summary.get("next_recompute_at")
+        st.metric(
+            "Next recompute",
+            next_run.strftime("%d %b %H:%M UTC") if next_run else "queued on demand",
+        )
+
+    latest = summary.get("latest")
+    if latest:
+        st.info(f"Latest invalidation: {latest.reason} at {latest.invalidated_at.strftime('%d %b %Y %H:%M UTC')}")
+    else:
+        st.success("No invalidations recorded for this case yet.")
+
+    if not invalidations:
+        st.caption("Nothing stale right now.")
+        return
+
+    for invalidation in invalidations:
+        stale_badge = "🟠" if invalidation.status != "completed" else "🟢"
+        with st.container(border=True):
+            st.markdown(f"{stale_badge} **{invalidation.scope_type.title()}** · {invalidation.scope_value}")
+            st.caption(f"Reason: {invalidation.reason} · Status: {invalidation.status}")
+            st.caption(
+                f"Invalidated: {invalidation.invalidated_at.strftime('%d %b %Y %H:%M UTC')}"
+                + (
+                    f" · Recompute: {invalidation.scheduled_for.strftime('%d %b %Y %H:%M UTC')}"
+                    if invalidation.scheduled_for
+                    else ""
+                )
+            )
+            details = invalidation.details or {}
+            if details:
+                changed_fields = details.get("changed_fields")
+                if changed_fields:
+                    st.write(f"Changed fields: {', '.join(changed_fields)}")
+                elif details:
+                    st.json(details)
+
+
 def render_case_actions(case: Dict, user_id: int):
     """Render case status actions"""
     st.subheader("🔧 Case Actions")
@@ -621,7 +677,7 @@ def main():
     st.markdown("---")
 
     # Main content - tabs
-    tab1, tab2, tab3, tab4, tab5 = st.tabs(["📅 Timeline", "📄 Documents", "⏰ Deadlines", "⚖️ Remedies", "🗒️ Notes"])
+    tab1, tab2, tab3, tab4, tab5, tab6 = st.tabs(["📅 Timeline", "📄 Documents", "⏰ Deadlines", "⚖️ Remedies", "📡 Knowledge", "🗒️ Notes"])
 
     with tab1:
         render_timeline_section(timeline)
@@ -636,6 +692,9 @@ def main():
         render_remedies_section(remedies)
 
     with tab5:
+        render_knowledge_status_section(case_id, user_id)
+
+    with tab6:
         render_case_notes_section(case_id, user_id)
 
     st.markdown("---")

--- a/pages/2_Case_Details.py
+++ b/pages/2_Case_Details.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone, timedelta
 from typing import Optional, Dict, Any
 
 from auth import require_auth, redirect_to_login, get_current_user_id
+from api.feature_flags import is_feature_enabled_for_user, get_feature_flag_manager
 import routes
 from case_manager import get_case_detail, upload_case_document, mark_deadline_completed, mark_deadline_incomplete, add_manual_deadline, mark_case_appealed, mark_case_closed, mark_case_active, generate_case_summary_text
 from case_manager import upload_case_attachment, get_case_note_state, save_case_note, publish_case_note_for_case, get_case_note_history_for_case
@@ -527,6 +528,25 @@ def render_remedies_section(remedies: Optional[Dict]):
 def render_knowledge_status_section(case_id: int, user_id: int):
     """Render the freshness dashboard for document-backed knowledge."""
     st.subheader("📡 Knowledge Status")
+
+    current_user_email = st.session_state.get("user_email", "")
+    current_user_role = st.session_state.get("user_role", "user")
+    feature_enabled = is_feature_enabled_for_user(
+        "knowledge_status_dashboard",
+        str(user_id),
+        attributes={"role": current_user_role, "email": current_user_email},
+        surface="ui",
+    )
+
+    if not feature_enabled:
+        st.info("This dashboard is being rolled out gradually. Check back soon.")
+        return
+
+    get_feature_flag_manager().mark_flag_used(
+        "knowledge_status_dashboard",
+        user_id=str(user_id),
+        surface="ui",
+    )
 
     db = SessionLocal()
     try:

--- a/scheduler.py
+++ b/scheduler.py
@@ -85,6 +85,7 @@ from db import (
     get_prefs_by_user_ids,
     UserPreference,
 )
+from db.crud.knowledge import process_due_knowledge_invalidations
 from notifications.reminder_engine import (
     plan_eligible_reminders,
     should_process_threshold,
@@ -106,6 +107,8 @@ _instance_id = str(uuid.uuid4())[:8]
 # Lock configuration
 LOCK_KEY = "legalassist:scheduler:lock"
 LOCK_TTL_SECONDS = 55 * 60  # 55 minutes to allow hourly job to complete
+KNOWLEDGE_LOCK_KEY = "legalassist:knowledge:lock"
+KNOWLEDGE_LOCK_TTL_SECONDS = 10 * 60
 
 
 def _get_redis_client():
@@ -307,6 +310,27 @@ def check_and_send_reminders():
             db.close()
 
 
+def recompute_due_knowledge_invalidations():
+    """Recompute stale knowledge artifacts after invalidations become due."""
+
+    lock_id = f"{_instance_id}:{os.getpid()}"
+    with distributed_lock(KNOWLEDGE_LOCK_KEY, KNOWLEDGE_LOCK_TTL_SECONDS, lock_id) as has_lock:
+        if not has_lock:
+            logger.debug("Skipping knowledge recompute - another instance holds the lock")
+            return
+
+        init_db()
+
+        db = SessionLocal()
+        try:
+            processed = process_due_knowledge_invalidations(db)
+            logger.info("Knowledge recompute job completed", processed=len(processed))
+        except Exception as exc:
+            logger.error(f"Error in knowledge recompute job: {exc}", exc_info=True)
+        finally:
+            db.close()
+
+
 def setup_scheduler(scheduler_class):
     """
     ============================================================================
@@ -400,6 +424,14 @@ def setup_scheduler(scheduler_class):
             name="Hourly Deadline Reminder Check",
             replace_existing=True
         )
+
+        scheduler.add_job(
+            recompute_due_knowledge_invalidations,
+            trigger=CronTrigger(minute="*/15", second=10),
+            id="knowledge_recompute_job",
+            name="Quarter-Hour Knowledge Recompute",
+            replace_existing=True,
+        )
         
         logger.info(f"Successfully configured {scheduler_class.__name__}")
         logger.info("Job store: SQLAlchemy (Persistent)")
@@ -454,6 +486,12 @@ def trigger_reminder_check_now():
     """
     logger.info("Manually triggering reminder check...")
     check_and_send_reminders()
+
+
+def trigger_knowledge_recompute_now():
+    """Manually trigger the knowledge recompute job (useful for testing/debugging)."""
+    logger.info("Manually triggering knowledge recompute...")
+    recompute_due_knowledge_invalidations()
 
 
 def run_worker():

--- a/sdk/javascript/client.js
+++ b/sdk/javascript/client.js
@@ -2,6 +2,13 @@
 JavaScript/TypeScript Client SDK for Legalassist-AI API
 """
 
+function generateIdempotencyKey() {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `idemp_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+}
+
 
 class LegalassistClient {
   constructor(options = {}) {
@@ -28,6 +35,10 @@ class LegalassistClient {
       headers["Authorization"] = `Bearer ${this.token}`;
     }
 
+    if (["POST", "PUT", "PATCH", "DELETE"].includes(method.toUpperCase())) {
+      headers["Idempotency-Key"] = options.idempotencyKey || generateIdempotencyKey();
+    }
+
     const config = {
       method,
       headers,
@@ -52,15 +63,17 @@ class LegalassistClient {
   async getToken(username, password) {
     return this.request("POST", "/api/v1/auth/token", {
       body: JSON.stringify({ username, password }),
+      idempotencyKey: generateIdempotencyKey(),
     });
   }
 
-  async createApiKey(name, expiresInDays = null) {
+  async createApiKey(name, expiresInDays = null, idempotencyKey = null) {
     return this.request("POST", "/api/v1/auth/api-keys", {
       body: JSON.stringify({
         name,
         expires_in_days: expiresInDays,
       }),
+      idempotencyKey,
     });
   }
 
@@ -85,6 +98,7 @@ class LegalassistClient {
 
     return this.request("POST", "/api/v1/analyze/document", {
       body: JSON.stringify(payload),
+      idempotencyKey: options.idempotencyKey || generateIdempotencyKey(),
     });
   }
 
@@ -136,6 +150,7 @@ class LegalassistClient {
         jurisdiction,
         limit,
       }),
+      idempotencyKey: options.idempotencyKey || generateIdempotencyKey(),
     });
   }
 
@@ -160,6 +175,7 @@ class LegalassistClient {
         report_type: reportType,
         format,
       }),
+      idempotencyKey: options.idempotencyKey || generateIdempotencyKey(),
     });
   }
 
@@ -215,6 +231,7 @@ class LegalassistClient {
         description,
         priority,
       }),
+      idempotencyKey: options.idempotencyKey || generateIdempotencyKey(),
     });
   }
 

--- a/sdk/python/client.py
+++ b/sdk/python/client.py
@@ -5,6 +5,13 @@ import httpx
 from typing import Optional, Dict, Any, List
 import asyncio
 import time
+import uuid
+
+
+def _with_idempotency_headers(headers: Dict[str, str], idempotency_key: Optional[str] = None) -> Dict[str, str]:
+    merged = dict(headers)
+    merged["Idempotency-Key"] = idempotency_key or str(uuid.uuid4())
+    return merged
 
 
 class LegalassistClient:
@@ -56,12 +63,12 @@ class LegalassistClient:
         response = self.client.post(
             f"{self.base_url}/api/v1/auth/token",
             data={"username": username, "password": password},
-            headers=self.headers
+            headers=_with_idempotency_headers(self.headers)
         )
         response.raise_for_status()
         return response.json()
     
-    def create_api_key(self, name: str, expires_in_days: Optional[int] = None) -> Dict[str, Any]:
+    def create_api_key(self, name: str, expires_in_days: Optional[int] = None, idempotency_key: Optional[str] = None) -> Dict[str, Any]:
         """Create new API key"""
         payload = {"name": name}
         if expires_in_days:
@@ -70,7 +77,7 @@ class LegalassistClient:
         response = self.client.post(
             f"{self.base_url}/api/v1/auth/api-keys",
             json=payload,
-            headers=self.headers
+            headers=_with_idempotency_headers(self.headers, idempotency_key)
         )
         response.raise_for_status()
         return response.json()
@@ -93,7 +100,8 @@ class LegalassistClient:
         text: Optional[str] = None,
         file_url: Optional[str] = None,
         document_type: str = "unknown",
-        extract_remedies: bool = True
+        extract_remedies: bool = True,
+        idempotency_key: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Analyze document asynchronously
@@ -115,7 +123,7 @@ class LegalassistClient:
         response = self.client.post(
             f"{self.base_url}/api/v1/analyze/document",
             json=payload,
-            headers=self.headers
+            headers=_with_idempotency_headers(self.headers, idempotency_key)
         )
         response.raise_for_status()
         return response.json()
@@ -167,7 +175,8 @@ class LegalassistClient:
         self,
         keywords: Optional[List[str]] = None,
         jurisdiction: str = "US",
-        limit: int = 10
+        limit: int = 10,
+        idempotency_key: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Search for cases"""
         payload = {
@@ -179,7 +188,7 @@ class LegalassistClient:
         response = self.client.post(
             f"{self.base_url}/api/v1/cases/search",
             json=payload,
-            headers=self.headers
+            headers=_with_idempotency_headers(self.headers, idempotency_key)
         )
         response.raise_for_status()
         return response.json()
@@ -201,7 +210,8 @@ class LegalassistClient:
         self,
         case_id: str,
         report_type: str = "comprehensive",
-        format: str = "pdf"
+        format: str = "pdf",
+        idempotency_key: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Generate report asynchronously"""
         payload = {
@@ -213,7 +223,7 @@ class LegalassistClient:
         response = self.client.post(
             f"{self.base_url}/api/v1/reports/generate",
             json=payload,
-            headers=self.headers
+            headers=_with_idempotency_headers(self.headers, idempotency_key)
         )
         response.raise_for_status()
         return response.json()
@@ -266,7 +276,8 @@ class LegalassistClient:
         title: str,
         due_date: str,
         description: str = "",
-        priority: str = "medium"
+        priority: str = "medium",
+        idempotency_key: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Create new deadline"""
         payload = {
@@ -279,7 +290,7 @@ class LegalassistClient:
         response = self.client.post(
             f"{self.base_url}/api/v1/deadlines",
             json=payload,
-            headers=self.headers
+            headers=_with_idempotency_headers(self.headers, idempotency_key)
         )
         response.raise_for_status()
         return response.json()

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -4,7 +4,7 @@ import os
 import pytest
 from unittest.mock import MagicMock
 
-from api.feature_flags import FeatureFlagManager, get_feature_flag_manager
+from api.feature_flags import FeatureFlagManager, FeatureFlagDefinition, get_feature_flag_manager
 
 
 def test_defaults_and_env_override(monkeypatch):
@@ -40,3 +40,71 @@ def test_get_feature_flag_manager_singleton():
     m1 = get_feature_flag_manager()
     m2 = get_feature_flag_manager()
     assert m1 is m2
+
+
+def test_deterministic_user_bucketing():
+    definition = FeatureFlagDefinition(
+        name="knowledge_status_dashboard",
+        rollout_percent=10,
+        targeting_rules={"roles": ["user", "admin"]},
+    )
+    manager = FeatureFlagManager(definitions=[definition])
+
+    bucket_a_1 = manager._deterministic_bucket("knowledge_status_dashboard", "user-123")
+    bucket_a_2 = manager._deterministic_bucket("knowledge_status_dashboard", "user-123")
+    bucket_b = manager._deterministic_bucket("knowledge_status_dashboard", "user-456")
+
+    assert bucket_a_1 == bucket_a_2
+    assert 0 <= bucket_a_1 < 100
+    assert 0 <= bucket_b < 100
+
+    enabled_first = manager.is_enabled_for_user(
+        "knowledge_status_dashboard",
+        "user-123",
+        attributes={"role": "user"},
+        surface="ui",
+        record_event=False,
+    )
+    enabled_second = manager.is_enabled_for_user(
+        "knowledge_status_dashboard",
+        "user-123",
+        attributes={"role": "user"},
+        surface="ui",
+        record_event=False,
+    )
+
+    assert enabled_first == enabled_second
+
+
+def test_targeting_rules_and_flag_events(monkeypatch):
+    definition = FeatureFlagDefinition(
+        name="beta_panel",
+        rollout_percent=100,
+        targeting_rules={"roles": ["admin"], "attributes": {"region": {"equals": "in"}}},
+    )
+    manager = FeatureFlagManager(definitions=[definition])
+
+    events = []
+
+    def capture_event(event, flag_name, *, surface="api", variant="control"):
+        events.append((event, flag_name, surface, variant))
+
+    monkeypatch.setattr("api.feature_flags.record_feature_flag_event", capture_event)
+
+    assert manager.is_enabled_for_user(
+        "beta_panel",
+        "user-1",
+        attributes={"role": "admin", "region": "in"},
+        surface="api",
+    ) is True
+    manager.mark_flag_used("beta_panel", user_id="user-1", surface="api")
+
+    assert manager.is_enabled_for_user(
+        "beta_panel",
+        "user-2",
+        attributes={"role": "user", "region": "in"},
+        surface="ui",
+    ) is False
+
+    assert any(event[0] == "flag_shown" and event[1] == "BETA_PANEL" and event[2] == "api" for event in events)
+    assert any(event[0] == "flag_used" and event[1] == "BETA_PANEL" and event[2] == "api" for event in events)

--- a/tests/test_http_idempotency.py
+++ b/tests/test_http_idempotency.py
@@ -1,0 +1,74 @@
+"""Tests for HTTP idempotency-key behavior."""
+
+import os
+
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("CELERY_BROKER_URL", "redis://localhost:6379/1")
+os.environ.setdefault("CELERY_RESULT_BACKEND", "redis://localhost:6379/2")
+os.environ.setdefault("JWT_SECRET", "test-secret-key-for-idempotency")
+os.environ.setdefault("APP_ALLOWED_HOSTS", "localhost,127.0.0.1")
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.middleware import idempotency_middleware, http_idempotency_manager
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+
+    def set(self, key, value, nx=False, ex=None):
+        if nx and key in self.store:
+            return False
+        self.store[key] = value
+        return True
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def delete(self, key):
+        return self.store.pop(key, None) is not None
+
+
+def build_app():
+    app = FastAPI()
+    app.middleware("http")(idempotency_middleware)
+
+    counter = {"value": 0}
+
+    @app.post("/resources")
+    async def create_resource(payload: dict):
+        counter["value"] += 1
+        return {"created": True, "counter": counter["value"], "payload": payload}
+
+    return app, counter
+
+
+def test_write_requests_require_idempotency_key():
+    app, _counter = build_app()
+    client = TestClient(app)
+
+    response = client.post("/resources", json={"name": "alpha"})
+
+    assert response.status_code == 428
+    assert response.json()["error_code"] == "IDEMPOTENCY_KEY_REQUIRED"
+
+
+def test_repeated_write_requests_return_same_result(monkeypatch):
+    app, counter = build_app()
+    client = TestClient(app)
+
+    fake = FakeRedis()
+    http_idempotency_manager._client = fake
+
+    headers = {"Idempotency-Key": "resource-key-1"}
+
+    first = client.post("/resources", json={"name": "alpha"}, headers=headers)
+    second = client.post("/resources", json={"name": "alpha"}, headers=headers)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json() == second.json()
+    assert second.headers.get("X-Idempotent-Replay") == "true"
+    assert counter["value"] == 1

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -58,8 +58,8 @@ def test_analyze_task_skips_when_duplicate(monkeypatch):
             return None
 
     with patch("celery_app.IdempotencyManager", return_value=fake_manager):
-        # call underlying wrapped function with a dummy self
-        res = celery_app.analyze_document_task.__wrapped__(_Self(), "u1", "d1", "text")
+        # call the stable task wrapper interface with a dummy self
+        res = celery_app.analyze_document_task.run(_Self(), "u1", "d1", "text")
         assert res["document_id"] == "d1"
         assert res["summary"] == "already"
 
@@ -83,7 +83,39 @@ def test_generate_report_marks_completed(monkeypatch):
             fake_manager.mark_completed("report:stub", result)
             return result
 
-        celery_app.generate_report_task.__wrapped__ = _stub
-        res = celery_app.generate_report_task.__wrapped__(None, "u1", "case1")
+        celery_app.generate_report_task.run = _stub
+        res = celery_app.generate_report_task.run(None, "u1", "case1")
         assert fake_manager.mark_completed.called
         assert res["report_id"] == "stubbed"
+
+
+def test_python_sdk_sends_idempotency_key(monkeypatch):
+    from sdk.python.client import LegalassistClient
+
+    captured = {}
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"ok": True}
+
+    class FakeHttpClient:
+        def post(self, url, **kwargs):
+            captured["url"] = url
+            captured["headers"] = kwargs.get("headers", {})
+            captured["json"] = kwargs.get("json")
+            captured["data"] = kwargs.get("data")
+            return FakeResponse()
+
+        def close(self):
+            return None
+
+    client = LegalassistClient(api_key="api-key")
+    client.client = FakeHttpClient()
+
+    client.create_api_key("Example")
+
+    assert captured["headers"].get("Idempotency-Key")
+    assert captured["headers"].get("X-API-Key") == "api-key"

--- a/tests/test_knowledge_invalidation.py
+++ b/tests/test_knowledge_invalidation.py
@@ -1,0 +1,128 @@
+"""Tests for knowledge invalidation persistence and recompute tracking."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from db.base import Base
+from db.models import Case, CaseStatus, DocumentType, KnowledgeInvalidationStatus, User
+from db.case_service import create_case_document, update_case_document
+from db.crud.knowledge import (
+    list_knowledge_invalidations,
+    process_due_knowledge_invalidations,
+    record_knowledge_invalidation,
+)
+
+
+@pytest.fixture
+def test_db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db = TestingSessionLocal()
+    yield db
+    db.close()
+
+
+def _create_user_and_case(db):
+    user = User(id=1, email="user@example.com")
+    db.add(user)
+    db.commit()
+
+    case = Case(
+        user_id=1,
+        case_number="CASE-100",
+        case_type="civil",
+        jurisdiction="Delhi",
+        status=CaseStatus.ACTIVE,
+        title="Test Case",
+    )
+    db.add(case)
+    db.commit()
+    db.refresh(case)
+    return user, case
+
+
+def test_create_case_document_records_document_created_invalidation(test_db):
+    _user, case = _create_user_and_case(test_db)
+
+    doc = create_case_document(
+        test_db,
+        case_id=case.id,
+        document_type=DocumentType.JUDGMENT,
+        user_id=1,
+        document_content="Initial judgment text",
+        summary="Initial summary",
+    )
+
+    rows = list_knowledge_invalidations(test_db, case_id=case.id)
+    assert len(rows) == 1
+
+    invalidation = rows[0]
+    assert invalidation.case_id == case.id
+    assert invalidation.document_id == doc.id
+    assert invalidation.reason == "document_created"
+    assert invalidation.scope_type == "case"
+    assert invalidation.scope_value == f"case:{case.id}"
+    assert invalidation.status == KnowledgeInvalidationStatus.PENDING.value
+    assert invalidation.details["document_type"] == DocumentType.JUDGMENT.value
+    assert "changed_fields" in invalidation.details
+
+
+def test_update_case_document_tracks_reason_and_changed_fields(test_db):
+    _user, case = _create_user_and_case(test_db)
+
+    doc = create_case_document(
+        test_db,
+        case_id=case.id,
+        document_type=DocumentType.JUDGMENT,
+        user_id=1,
+        document_content="Initial judgment text",
+        summary="Initial summary",
+    )
+
+    updated = update_case_document(
+        test_db,
+        document_id=doc.id,
+        summary="Updated summary",
+        ocr_used=True,
+    )
+
+    assert updated is not None
+
+    rows = list_knowledge_invalidations(test_db, case_id=case.id)
+    assert len(rows) == 2
+
+    latest = rows[0]
+    assert latest.reason == "summary_updated"
+    assert latest.details["changed_fields"] == ["summary", "ocr_used"]
+    assert latest.document_id == doc.id
+    assert latest.status == KnowledgeInvalidationStatus.PENDING.value
+
+
+def test_due_knowledge_invalidations_are_processed(test_db):
+    _user, case = _create_user_and_case(test_db)
+
+    record_knowledge_invalidation(
+        test_db,
+        scope_type="case",
+        case_id=case.id,
+        user_id=1,
+        reason="manual_refresh",
+        scheduled_for=datetime.now(timezone.utc) - timedelta(minutes=5),
+        details={"changed_fields": ["summary"]},
+    )
+
+    processed = process_due_knowledge_invalidations(
+        test_db,
+        recompute_handler=lambda db, invalidation: True,
+    )
+
+    assert len(processed) == 1
+    refreshed = list_knowledge_invalidations(test_db, case_id=case.id)[0]
+    assert refreshed.status == KnowledgeInvalidationStatus.COMPLETED.value
+    assert refreshed.recompute_attempts == 1
+    assert refreshed.recompute_started_at is not None
+    assert refreshed.recompute_completed_at is not None


### PR DESCRIPTION
Added the user-scoped feature-flag framework with deterministic bucketing and rollout metadata. The core schema and evaluator live in feature_flags.py and feature_flags.py, with per-user evaluation and rollout selection in feature_flags.py and feature_flags.py. I also added shared analytics events for `flag_shown` and `flag_used` in instrumentation.py and instrumentation.py.

The new Knowledge Status panel and its API backing route now both consult the same user-bucketed flag helper, so UI and API stay aligned. See 2_Case_Details.py and knowledge.py. The default rollout is controlled by `FEATURE_KNOWLEDGE_STATUS_DASHBOARD_ROLLOUT` and currently defaults to 10%.

Tests cover deterministic bucketing, targeting rules, and analytics event emission in test_feature_flags.py and test_feature_flags.py. Validation passed with `pytest test_feature_flags.py -q` and it completed with 6 passed.

One note: `get_errors` still reports pre-existing import resolution warnings in 2_Case_Details.py for `pytz` and `pypdf`; those were already present and are unrelated to this feature work.


closes #735