### PR TITLE
Privacy Mode: Redaction Profiles

### DIFF
--- a/case_manager.py
+++ b/case_manager.py
@@ -700,9 +700,9 @@ def _generate_anonymized_case_id(case_id: int, created_at: Any) -> str:
     return _generate_anonymized_case_id_service(case_id, created_at)
 
 
-def generate_anonymized_case_data(case_id: int) -> Optional[Dict[str, Any]]:
+def generate_anonymized_case_data(case_id: int, profile_name: Optional[str] = None) -> Optional[Dict[str, Any]]:
     try:
-        return generate_anonymized_case_data_service(case_id)
+        return generate_anonymized_case_data_service(case_id, profile_name=profile_name)
     except Exception as e:
         logger.error(f"Error generating anonymized data: {str(e)}")
         return None

--- a/config.py
+++ b/config.py
@@ -121,6 +121,10 @@ class Config:
     EXPORTS_DIR = _get_val("EXPORTS_DIR", str(PROJECT_ROOT / ".exports"))
     # Hours before export files expire and can be deleted
     EXPORT_FILE_EXPIRY_HOURS = _get_int_env("EXPORT_FILE_EXPIRY_HOURS", 24)
+    # Default privacy redaction profile for anonymized exports and reports
+    DEFAULT_PRIVACY_PROFILE = _get_val("DEFAULT_PRIVACY_PROFILE", "personal_identifiers")
+    # Optional JSON override for privacy profile definitions
+    PRIVACY_REDACTION_PROFILES_JSON = _get_val("PRIVACY_REDACTION_PROFILES_JSON", "")
     
     # --- Database Settings ---
     DATABASE_URL = _get_val("DATABASE_URL", "sqlite:///./legalassist.db")

--- a/pages/2_Case_Details.py
+++ b/pages/2_Case_Details.py
@@ -733,6 +733,17 @@ def main():
         get_default_export_fields,
         get_export_field_options,
     )
+    from services.privacy_redaction import get_default_privacy_profile, get_privacy_profile_options
+
+    privacy_profile_options = get_privacy_profile_options()
+    privacy_profile_labels = {item["name"]: item["label"] for item in privacy_profile_options}
+    privacy_profile = st.selectbox(
+        "Privacy profile",
+        options=[item["name"] for item in privacy_profile_options],
+        index=[item["name"] for item in privacy_profile_options].index(get_default_privacy_profile()),
+        format_func=lambda profile_name: privacy_profile_labels.get(profile_name, profile_name.replace("_", " ").title()),
+        key=f"privacy_profile_{case_id}",
+    )
 
     export_field_options = get_export_field_options()
     export_fields = st.multiselect(
@@ -766,6 +777,7 @@ def main():
         user_id=user_id,
         case_id=preview_case_id,
         field_ids=export_fields,
+        privacy_profile=privacy_profile,
     )
 
     with st.expander("Preview selected fields", expanded=False):
@@ -783,6 +795,7 @@ def main():
                     case_id=selected_case_ids[0],
                     format=export_formats[0],
                     field_ids=export_fields,
+                    privacy_profile=privacy_profile,
                 )
                 if export_artifact:
                     st.download_button(
@@ -799,6 +812,7 @@ def main():
                     case_ids=selected_case_ids,
                     field_ids=export_fields,
                     formats=export_formats,
+                    privacy_profile=privacy_profile,
                 )
                 if export_artifact:
                     st.download_button(
@@ -814,10 +828,10 @@ def main():
         from pdf_exporter import generate_anonymized_pdf
         from case_manager import generate_anonymized_case_data
 
-        anon_data = generate_anonymized_case_data(case_id)
+        anon_data = generate_anonymized_case_data(case_id, profile_name=privacy_profile)
         if anon_data:
             anon_id = anon_data["anonymized_id"]
-            anon_pdf_bytes = generate_anonymized_pdf(case_id, anon_id, user_id)
+            anon_pdf_bytes = generate_anonymized_pdf(case_id, anon_id, user_id, profile_name=privacy_profile)
             if anon_pdf_bytes:
                 st.download_button(
                     label="🔗 Download Anonymized PDF for Lawyer",

--- a/pdf_exporter.py
+++ b/pdf_exporter.py
@@ -595,7 +595,7 @@ def generate_case_pdf(user_id: int, case_id: int) -> Optional[bytes]:
     finally:
         db.close()
 
-def generate_anonymized_pdf(case_id: int, anon_id: str, user_id: int) -> Optional[bytes]:
+def generate_anonymized_pdf(case_id: int, anon_id: str, user_id: int, profile_name: Optional[str] = None) -> Optional[bytes]:
     """
     Generate an anonymized PDF for external legal review.
     Strips all personal identifiers to maintain privacy.
@@ -613,6 +613,16 @@ def generate_anonymized_pdf(case_id: int, anon_id: str, user_id: int) -> Optiona
 
         documents = db.query(CaseDocument).filter(CaseDocument.case_id == case_id).all()
         timeline = db.query(CaseTimeline).filter(CaseTimeline.case_id == case_id).all()
+        from services.privacy_redaction import normalize_privacy_profile, get_privacy_profile_definition
+        selected_profile = normalize_privacy_profile(profile_name)
+        profile = get_privacy_profile_definition(selected_profile)
+
+        anonymized_data = None
+        try:
+            from case_manager import generate_anonymized_case_data
+            anonymized_data = generate_anonymized_case_data(case_id, profile_name=selected_profile)
+        except Exception:
+            anonymized_data = None
 
         pdf = LegalAssistPDF()
         pdf.add_page()
@@ -625,6 +635,7 @@ def generate_anonymized_pdf(case_id: int, anon_id: str, user_id: int) -> Optiona
         pdf.safe_set_font(pdf.main_font, '', 11)
         pdf.set_text_color(*TEXT_COLOR)
         pdf.cell(0, 8, f"Unique Reference ID: {anon_id}", 0, 1, 'C')
+        pdf.cell(0, 8, f"Privacy profile: {profile.get('label', selected_profile)}", 0, 1, 'C')
         pdf.ln(10)
 
         # Classification info
@@ -651,7 +662,16 @@ def generate_anonymized_pdf(case_id: int, anon_id: str, user_id: int) -> Optiona
 
         # Document abstracts
         pdf.section_header('Evidence Summary')
-        if documents:
+        if anonymized_data and anonymized_data.get("documents"):
+            for doc in anonymized_data["documents"]:
+                pdf.safe_set_font(pdf.main_font, 'B', 10)
+                pdf.cell(0, 7, f"Type: {doc.get('type', 'Document')}", 0, 1)
+                summary = doc.get("summary")
+                if summary:
+                    pdf.safe_set_font(pdf.main_font, '', 10)
+                    pdf.multi_cell(0, 5, str(summary))
+                pdf.ln(3)
+        elif documents:
             for doc in documents:
                 pdf.safe_set_font(pdf.main_font, 'B', 10)
                 pdf.cell(0, 7, f"Type: {doc.document_type.value}", 0, 1)
@@ -664,7 +684,13 @@ def generate_anonymized_pdf(case_id: int, anon_id: str, user_id: int) -> Optiona
 
         # Procedure Timeline
         pdf.section_header('Procedural Milestones')
-        if timeline:
+        if anonymized_data and anonymized_data.get("timeline"):
+            for event in anonymized_data["timeline"][:20]:
+                pdf.safe_set_font(pdf.main_font, 'B', 9)
+                pdf.cell(40, 6, str(event.get("event_type", "event")).replace('_', ' ').title(), 0, 0)
+                pdf.safe_set_font(pdf.main_font, '', 9)
+                pdf.cell(0, 6, str(event.get("description") or ""), 0, 1)
+        elif timeline:
             for event in timeline[:20]:
                 pdf.safe_set_font(pdf.main_font, 'B', 9)
                 pdf.cell(40, 6, event.event_date.strftime('%d %b %Y'), 0, 0)

--- a/services/case_anonymization.py
+++ b/services/case_anonymization.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import hmac
 import os
 from pathlib import Path
@@ -13,9 +14,15 @@ from sqlalchemy.orm import Session
 from db.session import SessionLocal
 from db.models import Case, CaseDocument, CaseTimeline
 from config import Config
+from services.privacy_redaction import (
+    apply_privacy_profile,
+    get_privacy_profile_definition,
+    normalize_privacy_profile,
+)
 
 # Minimum secret length required for anonymization secret
 _MIN_SECRET_LENGTH = 32
+logger = logging.getLogger(__name__)
 
 
 def _get_case_anonymization_secret(override: Optional[str] = None) -> str:
@@ -88,7 +95,7 @@ def _generate_anonymized_case_id(case_id: int, created_at: Any, secret_override:
     return digest[:12]
 
 
-def generate_anonymized_case_data(case_id: int) -> Optional[Dict[str, Any]]:
+def generate_anonymized_case_data(case_id: int, profile_name: Optional[str] = None) -> Optional[Dict[str, Any]]:
     db: Session = SessionLocal()
     try:
         case = db.query(Case).filter(Case.id == case_id).first()
@@ -97,10 +104,20 @@ def generate_anonymized_case_data(case_id: int) -> Optional[Dict[str, Any]]:
 
         documents = db.query(CaseDocument).filter(CaseDocument.case_id == case_id).all()
         timeline = db.query(CaseTimeline).filter(CaseTimeline.case_id == case_id).all()
+        selected_profile = normalize_privacy_profile(profile_name)
+        profile = get_privacy_profile_definition(selected_profile)
         anonymized_id = _generate_anonymized_case_id(case_id=case_id, created_at=case.created_at)
 
-        return {
+        payload = {
+            "export": {
+                "case_id": case_id,
+                "generated_at": None,
+                "privacy_profile": selected_profile,
+                "privacy_profile_label": profile.get("label", selected_profile),
+            },
             "anonymized_id": anonymized_id,
+            "privacy_profile": selected_profile,
+            "privacy_profile_label": profile.get("label", selected_profile),
             "case_type": case.case_type,
             "jurisdiction": case.jurisdiction,
             "status": case.status.value,
@@ -122,5 +139,7 @@ def generate_anonymized_case_data(case_id: int) -> Optional[Dict[str, Any]]:
             ],
             "created_date": case.created_at.strftime("%B %Y"),
         }
+
+        return apply_privacy_profile(payload, selected_profile, anonymized_id=anonymized_id)
     finally:
         db.close()

--- a/services/export_builder.py
+++ b/services/export_builder.py
@@ -20,6 +20,10 @@ from sqlalchemy.orm import Session
 
 from db.models import Attachment, Case, CaseDeadline, CaseDocument, CaseTimeline
 from database import SessionLocal
+from services.privacy_redaction import (
+    apply_privacy_profile,
+    normalize_privacy_profile,
+)
 
 
 ExportPayload = Dict[str, Any]
@@ -241,6 +245,7 @@ def build_case_export_payload(
     user_id: int,
     case_id: int,
     field_ids: Optional[Sequence[str]] = None,
+    privacy_profile: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     selected_fields = _normalize_fields(field_ids)
 
@@ -287,7 +292,7 @@ def build_case_export_payload(
         if "remedies" in selected_fields:
             payload["remedies"] = latest_document.remedies if latest_document else None
 
-        return payload
+        return apply_privacy_profile(payload, normalize_privacy_profile(privacy_profile))
 
 
 def _json_bytes(payload: Dict[str, Any]) -> bytes:
@@ -423,9 +428,15 @@ def build_case_export_artifact(
     case_id: int,
     format: str,
     field_ids: Optional[Sequence[str]] = None,
+    privacy_profile: Optional[str] = None,
 ) -> Optional[ExportArtifact]:
     selected_fields = _normalize_fields(field_ids)
-    payload = build_case_export_payload(user_id=user_id, case_id=case_id, field_ids=selected_fields)
+    payload = build_case_export_payload(
+        user_id=user_id,
+        case_id=case_id,
+        field_ids=selected_fields,
+        privacy_profile=privacy_profile,
+    )
     if not payload:
         return None
 
@@ -465,6 +476,7 @@ def build_case_export_bundle(
     case_ids: Sequence[int],
     field_ids: Optional[Sequence[str]] = None,
     formats: Sequence[str] = ("json", "pdf", "docx"),
+    privacy_profile: Optional[str] = None,
 ) -> Optional[ExportArtifact]:
     unique_case_ids = []
     seen_case_ids = set()
@@ -505,6 +517,7 @@ def build_case_export_bundle(
                     case_id=case_id,
                     format=format_name,
                     field_ids=selected_fields,
+                    privacy_profile=privacy_profile,
                 )
                 if not artifact:
                     continue
@@ -538,5 +551,11 @@ def get_case_export_preview(
     user_id: int,
     case_id: int,
     field_ids: Optional[Sequence[str]] = None,
+    privacy_profile: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
-    return build_case_export_payload(user_id=user_id, case_id=case_id, field_ids=field_ids)
+    return build_case_export_payload(
+        user_id=user_id,
+        case_id=case_id,
+        field_ids=field_ids,
+        privacy_profile=privacy_profile,
+    )

--- a/services/privacy_redaction.py
+++ b/services/privacy_redaction.py
@@ -1,0 +1,248 @@
+"""Config-driven privacy redaction profiles.
+
+Profiles are used by anonymized exports and privacy-aware report payloads.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from config import Config
+
+DEFAULT_PRIVACY_PROFILE = "personal_identifiers"
+PRIVACY_PROFILES_ENV = "PRIVACY_REDACTION_PROFILES_JSON"
+
+EMAIL_PATTERN = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+PHONE_PATTERN = re.compile(r"(?:(?:\+?\d[\d\s().-]{6,}\d))")
+
+DEFAULT_PRIVACY_PROFILES: Dict[str, Dict[str, Any]] = {
+    "personal_identifiers": {
+        "label": "Personal identifiers only",
+        "description": "Hide direct identifiers while keeping case structure and narrative context.",
+        "case_number_style": "anonymized",
+        "title_style": "redacted",
+        "mask_free_text": True,
+        "keep_document_summaries": True,
+        "keep_deadline_descriptions": True,
+        "keep_timeline_descriptions": True,
+        "keep_attachment_names": False,
+        "keep_remedies": True,
+        "keep_document_metadata": True,
+    },
+    "full_party_removal": {
+        "label": "Full party removal",
+        "description": "Remove free-form party-sensitive content and suppress narrative fields.",
+        "case_number_style": "redacted",
+        "title_style": "redacted",
+        "mask_free_text": True,
+        "keep_document_summaries": False,
+        "keep_deadline_descriptions": False,
+        "keep_timeline_descriptions": False,
+        "keep_attachment_names": False,
+        "keep_remedies": False,
+        "keep_document_metadata": False,
+    },
+}
+
+
+@dataclass(frozen=True)
+class PrivacyProfileOption:
+    name: str
+    label: str
+    description: str
+
+
+def _load_profile_overrides() -> Dict[str, Dict[str, Any]]:
+    raw = str(getattr(Config, "PRIVACY_REDACTION_PROFILES_JSON", "") or os.getenv(PRIVACY_PROFILES_ENV, "") or "").strip()
+    if not raw:
+        return {}
+    try:
+        loaded = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(loaded, dict):
+        return {}
+    overrides: Dict[str, Dict[str, Any]] = {}
+    for profile_name, profile_value in loaded.items():
+        if isinstance(profile_name, str) and isinstance(profile_value, dict):
+            overrides[profile_name] = profile_value
+    return overrides
+
+
+def get_privacy_profiles() -> Dict[str, Dict[str, Any]]:
+    profiles = copy.deepcopy(DEFAULT_PRIVACY_PROFILES)
+    for profile_name, override in _load_profile_overrides().items():
+        base = profiles.get(profile_name, {})
+        base.update(override)
+        profiles[profile_name] = base
+    return profiles
+
+
+def get_privacy_profile_options() -> List[Dict[str, str]]:
+    profiles = get_privacy_profiles()
+    return [
+        {
+            "name": name,
+            "label": profile.get("label", name.replace("_", " ").title()),
+            "description": profile.get("description", ""),
+        }
+        for name, profile in profiles.items()
+    ]
+
+
+def get_default_privacy_profile() -> str:
+    default_name = str(getattr(Config, "DEFAULT_PRIVACY_PROFILE", DEFAULT_PRIVACY_PROFILE) or DEFAULT_PRIVACY_PROFILE).strip()
+    if default_name in get_privacy_profiles():
+        return default_name
+    return DEFAULT_PRIVACY_PROFILE
+
+
+def normalize_privacy_profile(profile_name: Optional[str]) -> str:
+    profiles = get_privacy_profiles()
+    candidate = str(profile_name or "").strip()
+    if candidate in profiles:
+        return candidate
+    return get_default_privacy_profile()
+
+
+def get_privacy_profile_definition(profile_name: Optional[str]) -> Dict[str, Any]:
+    profiles = get_privacy_profiles()
+    normalized = normalize_privacy_profile(profile_name)
+    return profiles.get(normalized, profiles[get_default_privacy_profile()])
+
+
+def _mask_free_text(value: Any) -> Any:
+    if not isinstance(value, str) or not value:
+        return value
+    masked = EMAIL_PATTERN.sub("[redacted-email]", value)
+    masked = PHONE_PATTERN.sub("[redacted-phone]", masked)
+    return masked
+
+
+def _redact_case_identifier(case_number: Optional[str], anonymized_id: Optional[str], profile: Dict[str, Any]) -> str:
+    style = profile.get("case_number_style", "anonymized")
+    if style == "redacted":
+        return "REDACTED"
+    if anonymized_id:
+        return f"ANON-{anonymized_id}"
+    if case_number:
+        return f"ANON-{case_number[-6:]}" if len(case_number) >= 6 else "ANON-CASE"
+    return "ANON-CASE"
+
+
+def _redact_title(title: Optional[str], profile: Dict[str, Any]) -> str:
+    style = profile.get("title_style", "redacted")
+    if style == "redacted":
+        return "Redacted Matter"
+    return title or "Redacted Matter"
+
+
+def _redact_mapping(mapping: Dict[str, Any], profile: Dict[str, Any]) -> Dict[str, Any]:
+    result = copy.deepcopy(mapping)
+    if not result:
+        return result
+
+    if not profile.get("keep_document_metadata", True):
+        result.pop("extracted_metadata", None)
+        result.pop("source_attachment_id", None)
+    if not profile.get("keep_document_summaries", True):
+        result["summary"] = None
+    elif profile.get("mask_free_text", True):
+        result["summary"] = _mask_free_text(result.get("summary"))
+
+    if not profile.get("keep_deadline_descriptions", True) and "description" in result:
+        result["description"] = None
+    elif profile.get("mask_free_text", True) and "description" in result:
+        result["description"] = _mask_free_text(result.get("description"))
+
+    if not profile.get("keep_timeline_descriptions", True) and "description" in result:
+        result["description"] = None
+    elif profile.get("mask_free_text", True) and "description" in result:
+        result["description"] = _mask_free_text(result.get("description"))
+
+    if not profile.get("keep_attachment_names", True) and "original_filename" in result:
+        result["original_filename"] = None
+
+    if not profile.get("keep_remedies", True) and "remedies" in result:
+        result["remedies"] = None
+    elif profile.get("mask_free_text", True) and "remedies" in result:
+        result["remedies"] = _redact_any(result.get("remedies"), profile)
+
+    for key, value in list(result.items()):
+        if isinstance(value, str) and profile.get("mask_free_text", True):
+            result[key] = _mask_free_text(value)
+        elif isinstance(value, dict):
+            result[key] = _redact_mapping(value, profile)
+        elif isinstance(value, list):
+            result[key] = [_redact_any(item, profile) for item in value]
+
+    return result
+
+
+def _redact_any(value: Any, profile: Dict[str, Any]) -> Any:
+    if isinstance(value, dict):
+        return _redact_mapping(value, profile)
+    if isinstance(value, list):
+        return [_redact_any(item, profile) for item in value]
+    if isinstance(value, str) and profile.get("mask_free_text", True):
+        return _mask_free_text(value)
+    return value
+
+
+def apply_privacy_profile(
+    payload: Dict[str, Any],
+    profile_name: Optional[str],
+    anonymized_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    profile = get_privacy_profile_definition(profile_name)
+    result = copy.deepcopy(payload)
+
+    export_meta = result.setdefault("export", {})
+    export_meta["privacy_profile"] = normalize_privacy_profile(profile_name)
+    export_meta["privacy_profile_label"] = profile.get("label", export_meta["privacy_profile"])
+
+    case_section = result.get("case")
+    if isinstance(case_section, dict):
+        case_section["case_number"] = _redact_case_identifier(
+            case_section.get("case_number"),
+            anonymized_id,
+            profile,
+        )
+        case_section["title"] = _redact_title(case_section.get("title"), profile)
+
+    if "latest_document" in result and isinstance(result["latest_document"], dict):
+        result["latest_document"] = _redact_mapping(result["latest_document"], profile)
+    if "next_deadline" in result and isinstance(result["next_deadline"], dict):
+        result["next_deadline"] = _redact_mapping(result["next_deadline"], profile)
+
+    for section_name in ("documents", "deadlines", "timeline", "attachments"):
+        section = result.get(section_name)
+        if isinstance(section, list):
+            result[section_name] = [_redact_any(item, profile) for item in section]
+
+    if "remedies" in result and not profile.get("keep_remedies", True):
+        result["remedies"] = None
+    elif "remedies" in result:
+        result["remedies"] = _redact_any(result["remedies"], profile)
+
+    preserve_top_level_strings = {
+        "anonymized_id",
+        "privacy_profile",
+        "privacy_profile_label",
+        "case_type",
+        "jurisdiction",
+        "status",
+        "created_date",
+        "document_count",
+    }
+    if profile.get("mask_free_text", True):
+        for key, value in list(result.items()):
+            if isinstance(value, str) and key not in preserve_top_level_strings and key != "export":
+                result[key] = _mask_free_text(value)
+
+    return result

--- a/tests/test_privacy_profiles.py
+++ b/tests/test_privacy_profiles.py
@@ -1,0 +1,156 @@
+import os
+import sys
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+os.environ.setdefault("JWT_SECRET", "test-secret-key-that-is-long-enough")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("CELERY_BROKER_URL", "redis://localhost:6379/0")
+os.environ.setdefault("CELERY_RESULT_BACKEND", "redis://localhost:6379/0")
+os.environ.setdefault("APP_ALLOWED_HOSTS", "localhost,127.0.0.1")
+os.environ.setdefault("CASE_ANONYMIZATION_SECRET", "a" * 32)
+sys.modules["streamlit"] = MagicMock()
+sys.modules["pytesseract"] = MagicMock()
+sys.modules["pdf2image"] = MagicMock()
+
+import pytest  # noqa: E402
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+
+from database import Base  # noqa: E402
+from db.models import (  # noqa: E402
+    User,
+    Case,
+    CaseStatus,
+    CaseDocument,
+    CaseTimeline,
+    Attachment,
+    DocumentType,
+)
+from services import case_anonymization  # noqa: E402
+from services import export_builder  # noqa: E402
+
+
+@pytest.fixture(scope="function")
+def test_db():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    testing_session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db = testing_session_local()
+
+    user = User(id=1, email="test@example.com")
+    db.add(user)
+    db.commit()
+
+    yield db
+    db.close()
+
+
+@pytest.fixture(autouse=True)
+def patch_sessions(test_db, monkeypatch):
+    monkeypatch.setattr(case_anonymization, "SessionLocal", lambda: test_db)
+
+    @contextmanager
+    def mock_session_local():
+        yield test_db
+
+    monkeypatch.setattr(export_builder, "SessionLocal", mock_session_local)
+
+
+def _seed_privacy_case(test_db):
+    case = Case(
+        id=1,
+        user_id=1,
+        case_number="CASE-99999",
+        case_type="civil",
+        jurisdiction="Delhi",
+        status=CaseStatus.ACTIVE,
+        title="Rahul Sharma v. City Council",
+        created_at=datetime(2026, 5, 1, 10, 0, 0, tzinfo=timezone.utc),
+    )
+    document = CaseDocument(
+        id=10,
+        case_id=1,
+        document_type=DocumentType.JUDGMENT,
+        document_content="Judgment text",
+        uploaded_at=datetime(2026, 5, 2, 10, 0, 0, tzinfo=timezone.utc),
+        summary="Call Rahul at test@example.com or +1 415 555 2671.",
+        remedies={"next_step": "appeal"},
+        extracted_metadata={"source": "court"},
+        extraction_method="manual",
+        ocr_used=False,
+    )
+    timeline = CaseTimeline(
+        id=11,
+        case_id=1,
+        event_type="reminder",
+        event_date=datetime(2026, 5, 3, 10, 0, 0, tzinfo=timezone.utc),
+        description="Reminder for Rahul Sharma at test@example.com",
+        event_metadata={"message_preview": "Please call +1 415 555 2671"},
+    )
+    attachment = Attachment(
+        id=12,
+        user_id=1,
+        case_id=1,
+        original_filename="Rahul_Sharma_Affidavit.pdf",
+        stored_path="/tmp/Rahul_Sharma_Affidavit.pdf",
+        content_type="application/pdf",
+        size_bytes=2048,
+    )
+    test_db.add_all([case, document, timeline, attachment])
+    test_db.commit()
+
+
+def test_personal_identifiers_profile_masks_direct_identifiers(test_db):
+    _seed_privacy_case(test_db)
+
+    data = case_anonymization.generate_anonymized_case_data(1, profile_name="personal_identifiers")
+
+    assert data is not None
+    assert data["privacy_profile"] == "personal_identifiers"
+    assert data["privacy_profile_label"] == "Personal identifiers only"
+    assert data["case_type"] == "civil"
+    assert data["jurisdiction"] == "Delhi"
+    assert data["documents"][0]["summary"] is not None
+    assert "test@example.com" not in data["documents"][0]["summary"]
+    assert "+1 415 555 2671" not in data["documents"][0]["summary"]
+    assert "test@example.com" not in data["timeline"][0]["description"]
+    assert "+1 415 555 2671" not in data["timeline"][0]["metadata"]["message_preview"]
+    assert data["documents"][0]["remedies"] == {"next_step": "appeal"}
+
+
+def test_full_party_removal_profile_redacts_narrative_fields(test_db):
+    _seed_privacy_case(test_db)
+
+    data = case_anonymization.generate_anonymized_case_data(1, profile_name="full_party_removal")
+
+    assert data is not None
+    assert data["privacy_profile"] == "full_party_removal"
+    assert data["privacy_profile_label"] == "Full party removal"
+    assert data["case_type"] == "civil"
+    assert data["jurisdiction"] == "Delhi"
+    assert data["documents"][0]["summary"] is None
+    assert data["timeline"][0]["description"] is None
+    assert data["documents"][0]["remedies"] is None
+    assert data["attachments"][0]["original_filename"] is None
+
+
+def test_export_builder_applies_privacy_profile_by_default(test_db):
+    _seed_privacy_case(test_db)
+
+    payload = export_builder.build_case_export_payload(
+        user_id=1,
+        case_id=1,
+        field_ids=["case_number", "title", "documents", "timeline", "attachments", "remedies"],
+        privacy_profile="full_party_removal",
+    )
+
+    assert payload is not None
+    assert payload["export"]["privacy_profile"] == "full_party_removal"
+    assert payload["case"]["case_number"] == "REDACTED"
+    assert payload["case"]["title"] == "Redacted Matter"
+    assert payload["documents"][0]["summary"] is None
+    assert payload["timeline"][0]["description"] is None
+    assert payload["attachments"][0]["original_filename"] is None
+    assert payload["remedies"] is None


### PR DESCRIPTION
Added config-driven privacy redaction profiles with two built-in modes: personal identifiers only and full party removal. The shared redaction logic lives in privacy_redaction.py, and the anonymized case helper now accepts a profile name and emits profile metadata through case_anonymization.py. I also threaded the selected profile into the anonymized PDF path in pdf_exporter.py, the export builder in export_builder.py, and the case-details UI toggle in 2_Case_Details.py.

Tests for both redaction guarantees are in test_privacy_profiles.py. Validation-wise, the touched Python files byte-compiled cleanly; I couldn’t run the full pytest slice in this workspace because the available interpreter still lacks the project dependencies such as `sqlalchemy`.

closes #737