### PR TITLE
[Security] CSRF validation is only “token presence”, not token correctness

### DIFF
--- a/api/csrf.py
+++ b/api/csrf.py
@@ -8,13 +8,14 @@ Provides protection against CSRF attacks by:
 """
 
 import secrets
-import logging
+import structlog
 from typing import Optional, Set, Callable
 from fastapi import Request, HTTPException, status
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
+from api.config import get_settings
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 SAFE_METHODS: Set[str] = {"GET", "HEAD", "OPTIONS"}
 CSRF_TOKEN_HEADER = "X-CSRF-Token"
@@ -99,9 +100,16 @@ def validate_csrf_request(
 
     if require_token:
         token = request.headers.get(CSRF_TOKEN_HEADER) or request.headers.get(CSRF_TOKEN_HEADER.lower())
+        cookie_token = request.cookies.get(CSRF_COOKIE_NAME)
         if not token:
             logger.warning("csrf_missing_token", path=str(request.url.path))
             raise CSRFError(detail=f"Missing CSRF token. Include '{CSRF_TOKEN_HEADER}' header.")
+        if not cookie_token:
+            logger.warning("csrf_missing_cookie", path=str(request.url.path))
+            raise CSRFError(detail="Missing CSRF cookie.")
+        if not secrets.compare_digest(token, cookie_token):
+            logger.warning("csrf_token_mismatch", path=str(request.url.path))
+            raise CSRFError(detail="CSRF token mismatch.")
 
 
 class CSRFProtectionMiddleware(BaseHTTPMiddleware):
@@ -125,18 +133,48 @@ class CSRFProtectionMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         path = request.url.path
 
-        if path in self.exempt_paths or request.method in SAFE_METHODS:
+        if path in self.exempt_paths:
             return await call_next(request)
 
-        origin = get_origin(request)
-        if origin and not is_same_origin(request, self.allowed_hosts):
-            logger.warning("csrf_blocked", origin=origin, path=path)
-            return JSONResponse(
-                status_code=status.HTTP_403_FORBIDDEN,
-                content={"detail": "Cross-origin request blocked"},
+        # 1. Enforce token validation on state-mutating requests
+        if request.method not in SAFE_METHODS:
+            origin = get_origin(request)
+            if origin:
+                # If there's an Origin header, check same-origin and validate CSRF token
+                if not is_same_origin(request, self.allowed_hosts):
+                    logger.warning("csrf_cross_origin_blocked", origin=origin, path=path)
+                    return JSONResponse(
+                        status_code=status.HTTP_403_FORBIDDEN,
+                        content={"detail": "Cross-origin request blocked"},
+                    )
+                try:
+                    validate_csrf_request(request, allowed_hosts=self.allowed_hosts)
+                except CSRFError as exc:
+                    return JSONResponse(
+                        status_code=exc.status_code,
+                        content={"detail": exc.detail},
+                    )
+
+        # 2. Proceed with the request
+        response = await call_next(request)
+
+        # 3. Ensure csrf_token cookie is set on the response if not already present in the request's cookies
+        if CSRF_COOKIE_NAME not in request.cookies:
+            token = generate_csrf_token()
+            try:
+                settings = get_settings()
+                secure = settings.REQUIRE_HTTPS
+            except Exception:
+                secure = True
+            response.set_cookie(
+                CSRF_COOKIE_NAME,
+                token,
+                httponly=False,
+                samesite="lax",
+                secure=secure,
             )
 
-        return await call_next(request)
+        return response
 
 
 def csrf_protected(func: Callable) -> Callable:
@@ -161,3 +199,17 @@ def set_csrf_headers(response, token: str) -> None:
     response.headers["X-CSRF-Token"] = token
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"
+
+    # Also set the csrf_token cookie on the response
+    try:
+        settings = get_settings()
+        secure = settings.REQUIRE_HTTPS
+    except Exception:
+        secure = True
+    response.set_cookie(
+        CSRF_COOKIE_NAME,
+        token,
+        httponly=False,
+        samesite="lax",
+        secure=secure,
+    )

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -1,0 +1,99 @@
+import os
+import pytest
+
+# Configure environment variables before importing any config-dependent code
+os.environ["REDIS_URL"] = "redis://localhost:6379"
+os.environ["CELERY_BROKER_URL"] = "redis://localhost:6379"
+os.environ["CELERY_RESULT_BACKEND"] = "redis://localhost:6379"
+os.environ["APP_ALLOWED_HOSTS"] = "localhost"
+os.environ["JWT_SECRET_KEY"] = "test-secret-key-that-is-long-enough"
+
+from fastapi import FastAPI, Request, status
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from api.csrf import (
+    CSRFProtectionMiddleware,
+    CSRF_COOKIE_NAME,
+    CSRF_TOKEN_HEADER,
+    CSRFError,
+    validate_csrf_request,
+)
+
+# Create a clean, isolated FastAPI app for testing CSRF middleware
+app = FastAPI()
+app.add_middleware(
+    CSRFProtectionMiddleware,
+    allowed_hosts={"testserver", "localhost"},
+)
+
+@app.get("/test-get")
+def handle_get():
+    return {"message": "success"}
+
+@app.post("/test-post")
+def handle_post():
+    return {"message": "success"}
+
+client = TestClient(app)
+
+def test_get_sets_csrf_cookie():
+    """Test that a GET request (safe method) sets the csrf_token cookie on the response if missing."""
+    client.cookies.clear()
+    response = client.get("/test-get")
+    assert response.status_code == 200
+    assert CSRF_COOKIE_NAME in response.cookies
+    token = response.cookies[CSRF_COOKIE_NAME]
+    assert len(token) > 0
+
+def test_post_without_origin_bypasses_csrf():
+    """Test that a state-mutating request without an Origin header bypasses CSRF checks (for programmatic clients)."""
+    client.cookies.clear()
+    response = client.post("/test-post")
+    assert response.status_code == 200
+    assert response.json() == {"message": "success"}
+
+def test_post_with_origin_but_no_cookie_or_header_fails():
+    """Test that a state-mutating request with an Origin header but no CSRF cookie/header fails with 403."""
+    client.cookies.clear()
+    response = client.post("/test-post", headers={"Origin": "http://localhost"})
+    assert response.status_code == 403
+    assert "Missing CSRF token" in response.json()["detail"]
+
+def test_post_with_origin_and_header_but_no_cookie_fails():
+    """Test that a request with header but no cookie fails."""
+    client.cookies.clear()
+    headers = {
+        "Origin": "http://localhost",
+        "X-CSRF-Token": "some-token",
+    }
+    response = client.post("/test-post", headers=headers)
+    assert response.status_code == 403
+    assert "Missing CSRF cookie" in response.json()["detail"]
+
+def test_post_with_origin_and_mismatched_tokens_fails():
+    """Test that mismatched cookie and header values fail."""
+    client.cookies.clear()
+    headers = {
+        "Origin": "http://localhost",
+        "X-CSRF-Token": "header-token",
+    }
+    client.cookies.set(CSRF_COOKIE_NAME, "different-cookie-token")
+    response = client.post("/test-post", headers=headers)
+    assert response.status_code == 403
+    assert "CSRF token mismatch" in response.json()["detail"]
+    client.cookies.clear()
+
+def test_post_with_matching_tokens_succeeds():
+    """Test that matching cookie and header values succeed."""
+    client.cookies.clear()
+    token = "valid-csrf-token"
+    headers = {
+        "Origin": "http://localhost",
+        "X-CSRF-Token": token,
+    }
+    client.cookies.set(CSRF_COOKIE_NAME, token)
+    response = client.post("/test-post", headers=headers)
+    assert response.status_code == 200
+    assert response.json() == {"message": "success"}
+    client.cookies.clear()


### PR DESCRIPTION
I have successfully implemented and verified the CSRF token validation changes! Here is a summary of the accomplishments:

CSRF Validation Enhancements in 

csrf.py
:

Replaced the standard library logger with structlog to support structured logging with extra parameters.
Modified validate_csrf_request to fetch the cookie csrf_token and the request header X-CSRF-Token and assert their equality using timing-safe comparison (secrets.compare_digest).
Configured the middleware to automatically set the csrf_token cookie on safe requests if not already present.
Integrated CSRF checking on state-mutating requests (POST, PUT, PATCH, DELETE) when an Origin header is supplied.
Automated Testing in 



closes #808