### PR TITLE
[Security] Authentication drift risk: two auth implementations

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -127,6 +127,71 @@ def verify_token(token: str) -> Dict:
         raise InvalidTokenError("Invalid token")
 
 
+def revoke_jwt_token(token: str) -> bool:
+    """Revoke a JWT token by adding its JTI to the revocation table.
+
+    This verifies the token signature (but not expiration) against
+    current/previous secrets and enforces issuer/audience/type checks.
+    Returns True on success, False otherwise.
+    """
+    if not token:
+        return False
+
+    try:
+        # Fast path - extract without signature verification to get jti/exp
+        try:
+            unverified = jwt.decode(token, options={"verify_signature": False, "verify_exp": False})
+            jti = unverified.get("jti")
+            exp = unverified.get("exp")
+            if not jti or not exp:
+                return False
+        except Exception:
+            return False
+
+        payload = None
+        last_error = None
+        for secret in _get_jwt_secrets_to_try():
+            try:
+                payload = jwt.decode(
+                    token,
+                    secret,
+                    algorithms=[settings.JWT_ALGORITHM],
+                    issuer=settings.JWT_ISSUER,
+                    audience=settings.JWT_AUDIENCE,
+                    options={"verify_exp": False, "verify_signature": True, "require": ["exp", "iat", "iss", "aud", "jti", "type"]},
+                )
+                break
+            except jwt.InvalidTokenError as exc:
+                last_error = exc
+                continue
+
+        if payload is None:
+            return False
+
+        token_type = payload.get("type")
+        if token_type != "access":
+            return False
+
+        jti = payload.get("jti")
+        exp = payload.get("exp")
+        if not jti or not exp:
+            return False
+
+        # convert exp to datetime
+        expires_at = datetime.fromtimestamp(exp, tz=timezone.utc) if isinstance(exp, (int, float)) else exp
+
+        # Persist revocation
+        with SessionLocal() as db:
+            # db-level revoke_token is available via database shim
+            from database import revoke_token, is_token_revoked
+
+            if not is_token_revoked(db, jti):
+                revoke_token(db, jti, expires_at)
+        return True
+    except Exception:
+        return False
+
+
 # ============================================================================
 # API Key Management
 # ============================================================================

--- a/auth.py
+++ b/auth.py
@@ -378,195 +378,22 @@ def create_jwt_token(user_id: int, email: str) -> str:
         A fully encoded and cryptographically signed JWT string.
     """
     
-    # Generate a unique JWT ID (jti) to allow for future token revocation.
-    # The jti claim provides a unique identifier for the JWT, which can be 
-    # used to prevent the token from being replayed. We use a standard UUID4.
-    jti = str(uuid.uuid4())
-    
-    # Calculate the exact expiration time based on the configured hours
-    expiration_time = datetime.now(timezone.utc) + timedelta(hours=JWT_EXPIRY_HOURS)
-    
-    # Calculate the exact issued-at time
-    issued_at_time = datetime.now(timezone.utc)
-    
-    # Construct the JWT payload dictionary
-    payload = {
-        # --- Registered Claims (RFC 7519) ---
-        "jti": jti,                      # JWT ID
-        "exp": expiration_time,          # Expiration Time
-        "iat": issued_at_time,           # Issued At Time
-        "iss": Config.JWT_ISSUER,        # Issuer (Who created the token)
-        "aud": Config.JWT_AUDIENCE,      # Audience (Who the token is for)
-        
-        # --- Private/Custom Claims ---
-        "user_id": user_id,              # The user's internal DB ID
-        "email": email,                  # The user's email for quick reference
-        "type": "access",                # Token type to separate access from refresh/reset
-    }
-    
-    # Cryptographically sign the payload using our secret key and specified algorithm
-    encoded_token = jwt.encode(
-        payload=payload, 
-        key=Config.get_current_jwt_secret(), 
-        algorithm=JWT_ALGORITHM
-    )
-    
-    logger.debug("Created new JWT access token for user %s with jti %s", email, jti)
-    
-    return encoded_token
+    # Delegate JWT creation to the canonical API auth implementation
+    from api.auth import create_access_token
+
+    data = {"user_id": user_id, "email": email}
+    return create_access_token(data)
 
 
 def verify_jwt_token(token: str) -> Optional[dict]:
-    """
-    Verify a JWT token with strict validation checks and return its payload.
-    
-    This function acts as the primary gatekeeper for all protected resources.
-    It performs multiple layers of defense-in-depth validation:
-    
-    1. Cryptographic Signature Verification
-    2. Expiration (exp) Verification
-    3. Strict Issuer (iss) Validation
-    4. Strict Audience (aud) Validation
-    5. Token Purpose/Type Validation
-    6. State Verification (Database Revocation Check)
-    7. User Existence Verification
-    
-    Parameters:
-    -----------
-    token : str
-        The raw JWT string extracted from the user's session or Authorization header.
-        
-    Returns:
-    --------
-    Optional[dict]
-        The decoded payload dictionary if all checks pass.
-        Returns None if the token is invalid, expired, revoked, or fails any security check.
-    """
-    try:
-        # =====================================================================
-        # LAYER 1 & 2: CRYPTOGRAPHIC & REGISTERED CLAIM VERIFICATION
-        # =====================================================================
-        # This single call to jwt.decode() handles signature validation, 
-        # expiration checking, and now, strictly enforces issuer and audience.
-        # 
-        # By providing `issuer` and `audience` parameters, the pyjwt library 
-        # will automatically raise a jwt.InvalidTokenError (specifically, 
-        # InvalidIssuerError or InvalidAudienceError) if the token's claims 
-        # do not exactly match our expected values.
-        # 
-        # This completely prevents "Cross-JWT Confusion" attacks.
-        # =====================================================================
-        
-        last_error = None
-        payload = None
-        for secret in _get_jwt_secrets_to_try():
-            try:
-                payload = jwt.decode(
-                    jwt=token,
-                    key=secret,
-                    algorithms=[JWT_ALGORITHM],
-                    issuer=Config.JWT_ISSUER,
-                    audience=Config.JWT_AUDIENCE,
-                    options={"require": ["exp", "iat", "iss", "aud", "jti", "type"]},
-                )
-                break
-            except jwt.InvalidTokenError as exc:
-                last_error = exc
-                continue
+    """Delegate verification to the canonical API auth implementation.
 
-        if payload is None:
-            if isinstance(last_error, jwt.ExpiredSignatureError):
-                raise last_error
-            if isinstance(last_error, jwt.InvalidIssuerError):
-                raise last_error
-            if isinstance(last_error, jwt.InvalidAudienceError):
-                raise last_error
-            raise jwt.InvalidTokenError(str(last_error) if last_error else "Invalid token")
-        
-        # =====================================================================
-        # LAYER 3: TOKEN PURPOSE VALIDATION
-        # =====================================================================
-        # We explicitly set type="access" during token creation to prevent
-        # other types of tokens (e.g., password reset, email verification, 
-        # or API keys) from being used to gain interactive system access.
-        
-        token_type = payload.get("type")
-        
-        if token_type != "access":
-            logger.warning(
-                f"SECURITY ALERT: Invalid token type provided. "
-                f"Expected 'access', got '{token_type}'."
-            )
-            return None
-            
-        # Extract critical identity claims
-        jti = payload.get("jti")
-        email = payload.get("email")
-        
-        # Ensure that our required custom claims actually exist
-        if not email or not jti:
-            logger.warning("Token verification failed: payload missing required 'email' or 'jti' claim")
-            return None
-            
-        # =====================================================================
-        # LAYER 4 & 5: STATEFUL DATABASE VERIFICATIONS
-        # =====================================================================
-        # While JWTs are inherently stateless, we must occasionally rely on 
-        # stateful checks to handle immediate revocations (e.g., logout) or 
-        # account terminations.
-        
-        db = SessionLocal()
-        
-        try:
-            # Check the blacklist/revocation table.
-            # If a user explicitly clicked "Logout", their token's JTI was 
-            # added to this table. Even if the token hasn't technically expired 
-            # yet according to the `exp` claim, we must reject it.
-            
-            if is_token_revoked(db, jti):
-                logger.warning(f"Attempted to use explicitly revoked token (jti={jti}) for user {email}")
-                return None
-                
-            # Check the users table to guarantee the user hasn't been deleted 
-            # or suspended from the system by an administrator.
-            # A valid token is useless if the account itself is gone.
-            
-            user = get_user_by_email(db, email)
-            
-            if not user:
-                logger.warning(f"Token verification failed: User {email} no longer exists in DB")
-                return None
-                
-        finally:
-            # Always ensure the database connection is closed, even if an 
-            # exception occurs during the checks.
-            db.close()
-            
-        # --- ALL SECURITY CHECKS PASSED ---
-        return payload
-        
-    except jwt.ExpiredSignatureError:
-        # The token's `exp` claim is in the past. This is a normal, 
-        # expected occurrence when a session times out.
-        logger.info("JWT token expired gracefully.")
-        return None
-        
-    except jwt.InvalidIssuerError as e:
-        # The token was signed with the correct key, but originated from 
-        # an unexpected issuer. This is highly suspicious.
-        logger.error(f"SECURITY ALERT - Invalid Token Issuer detected: {str(e)}")
-        return None
-        
-    except jwt.InvalidAudienceError as e:
-        # The token was signed with the correct key and issuer, but was 
-        # intended for a different audience/service.
-        logger.error(f"SECURITY ALERT - Invalid Token Audience detected: {str(e)}")
-        return None
-        
-    except jwt.InvalidTokenError as e:
-        # Catch-all for any other structural or signature validation failures
-        # (e.g., malformed token, wrong signature, tampered payload).
-        logger.warning(f"Invalid JWT token structure or signature: {str(e)}")
+    Returns the payload dict on success or None on failure.
+    """
+    from api.auth import verify_token
+    try:
+        return verify_token(token)
+    except Exception:
         return None
 
 
@@ -589,107 +416,11 @@ def revoke_jwt_token(token: str) -> bool:
         True if the token was successfully added to the revocation list,
         False if the operation failed or the token was invalid.
     """
-    if not token:
-        logger.debug("Cannot revoke an empty token string.")
-        return False
-        
+    # Delegate revocation to the API auth implementation
+    from api.auth import revoke_jwt_token as _api_revoke
     try:
-        # Fast path: extract claims without signature verification
-        # This allows us to quickly reject malformed tokens before attempting expensive cryptographic verification.
-        try:
-            # We use verify_signature=False to just get the claims. 
-            # Note: We must still use a full verify_signature=True decode later for security.
-            unverified = jwt.decode(token, options={"verify_signature": False, "verify_exp": False})
-            jti = unverified.get("jti")
-            exp = unverified.get("exp")
-            
-            if not jti or not exp:
-                logger.error("Token payload missing required claims for revocation (jti or exp).")
-                return False
-        except Exception:
-            logger.error("Token structure invalid, could not extract claims for revocation.")
-            return False
-
-        # =====================================================================
-        # DECODING FOR REVOCATION (SIGNATURE VERIFIED, EXPIRATION SKIPPED)
-        # =====================================================================
-        # We need to extract the `jti` and `exp` claims to add them to our
-        # database blacklist.
-        #
-        # verify_exp=False: allows revoking tokens that expired moments ago,
-        # so the logout flow completes gracefully even for just-expired sessions.
-        #
-        # verify_signature=True (explicit): the HMAC signature MUST still be
-        # validated against the active or previous secrets.
-        #
-        # issuer and audience checks remain enforced to reject foreign tokens.
-        # =====================================================================
-
-        payload = None
-        last_error = None
-        for secret in _get_jwt_secrets_to_try():
-            try:
-                payload = jwt.decode(
-                    jwt=token,
-                    key=secret,
-                    algorithms=[JWT_ALGORITHM],
-                    issuer=Config.JWT_ISSUER,
-                    audience=Config.JWT_AUDIENCE,
-                    options={"verify_exp": False, "verify_signature": True, "require": ["exp", "iat", "iss", "aud", "jti", "type"]},
-                )
-                break
-            except jwt.InvalidTokenError as exc:
-                last_error = exc
-                continue
-
-        if payload is None:
-            raise last_error or jwt.InvalidTokenError("Invalid token")
-        
-        jti = payload.get("jti")
-        exp = payload.get("exp")
-        token_type = payload.get("type")
-        
-        if token_type != "access":
-            logger.warning("Attempted to revoke a non-access token")
-            return False
-
-        if not jti or not exp:
-            logger.error("Token payload missing required claims for revocation (jti or exp).")
-            return False
-            
-        # Convert the numeric timestamp back into a timezone-aware datetime object
-        expires_at = datetime.fromtimestamp(exp, tz=timezone.utc)
-        
-        db = SessionLocal()
-        
-        try:
-            # Check if it's already revoked to avoid duplicate inserts or unique 
-            # constraint violations in the database.
-            if not is_token_revoked(db, jti):
-                
-                # Insert the JTI and Expiration into the blacklist table.
-                # We store the expiration so that a background job can eventually 
-                # purge old revocation records once the token would have naturally 
-                # expired anyway, keeping the blacklist table small and fast.
-                revoke_token(db, jti, expires_at)
-                
-                logger.info(f"Successfully blacklisted/revoked token with jti={jti}")
-            else:
-                logger.debug(f"Token with jti={jti} was already revoked.")
-                
-            return True
-            
-        finally:
-            db.close()
-            
-    except jwt.InvalidIssuerError:
-        logger.warning("Attempted to revoke a token with an invalid issuer.")
-        return False
-    except jwt.InvalidAudienceError:
-        logger.warning("Attempted to revoke a token with an invalid audience.")
-        return False
-    except Exception as e:
-        logger.error(f"Unexpected error while revoking token: {str(e)}")
+        return _api_revoke(token)
+    except Exception:
         return False
 
 
@@ -712,28 +443,19 @@ def get_current_user_from_token(token: str) -> Optional[User]:
         The User ORM model if the token is valid and the user exists.
         Returns None otherwise.
     """
-    # First, pass the token through our rigorous verification pipeline
+    # Map to underlying API auth verification, then return ORM user if present
     payload = verify_jwt_token(token)
-    
     if not payload:
-        # The token failed verification (expired, invalid signature, bad iss/aud, etc.)
+        return None
+
+    email = payload.get("email")
+    if not email:
         return None
 
     db = SessionLocal()
-    
     try:
-        # Lookup the user by the email extracted from the validated payload
-        email = payload.get("email")
-        
-        if not email:
-            return None
-            
-        user = get_user_by_email(db, email)
-        
-        return user
-        
+        return get_user_by_email(db, email)
     finally:
-        # Always clean up the database session
         db.close()
 
 

--- a/tests/test_api_protected_auth_deps.py
+++ b/tests/test_api_protected_auth_deps.py
@@ -1,0 +1,36 @@
+import inspect
+from api.main import create_app
+
+PROTECTED_DEP_NAMES = {"get_current_user", "get_admin_user", "get_attorney_user"}
+
+
+def _collect_dependency_calls(route):
+    calls = []
+    dependant = getattr(route, "dependant", None)
+    if not dependant:
+        return calls
+    for dep in getattr(dependant, "dependencies", []) or []:
+        call = getattr(dep, "call", None)
+        if call and inspect.isfunction(call):
+            calls.append(call)
+    return calls
+
+
+def test_api_protected_routes_use_api_auth():
+    """Ensure any route depending on auth uses the canonical `api.auth` module.
+
+    This guards against drift where some routes import auth helpers
+    from the top-level `auth` module instead of the API-specific
+    `api.auth` implementation.
+    """
+    app = create_app()
+    mismatches = []
+
+    for route in app.routes:
+        calls = _collect_dependency_calls(route)
+        for call in calls:
+            if call.__name__ in PROTECTED_DEP_NAMES:
+                if not (call.__module__ or "").startswith("api.auth"):
+                    mismatches.append(f"{route.path} -> {call.__module__}.{call.__name__}")
+
+    assert not mismatches, "Protected routes using non-api.auth dependencies:\n" + "\n".join(mismatches)


### PR DESCRIPTION
Progress update:
- Implemented canonicalization: auth.py is the canonical API auth.
- Delegated root auth.py JWT helpers to `api.auth` (keeps Streamlit API compatibility).
- Added `revoke_jwt_token` to auth.py.
- Added test test_api_protected_auth_deps.py to ensure API routes use `api.auth` dependencies.

closes #810