### PR TITLE
Standardize error payloads

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -13,6 +13,7 @@ import hashlib
 from sqlalchemy.orm import Session
 
 from api.config import get_settings
+from api.errors import StructuredAPIError
 from database import SessionLocal
 from db.models import APIKey, User
 
@@ -204,33 +205,21 @@ async def get_current_user(
         try:
             payload = verify_token(token)
         except TokenExpiredError:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Token has expired"
-            )
+            raise StructuredAPIError(status_code=status.HTTP_401_UNAUTHORIZED, error_code="TOKEN_EXPIRED", message="Token has expired")
         except InvalidTokenError:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid token"
-            )
+            raise StructuredAPIError(status_code=status.HTTP_401_UNAUTHORIZED, error_code="INVALID_TOKEN", message="Invalid token")
 
         user_id = payload.get("sub")
         token_email = payload.get("email")
 
         if not user_id:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid token payload"
-            )
+            raise StructuredAPIError(status_code=status.HTTP_401_UNAUTHORIZED, error_code="INVALID_TOKEN_PAYLOAD", message="Invalid token payload")
 
         db = SessionLocal()
         try:
             user = db.query(User).filter(User.id == int(user_id)).first()
             if not user:
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="User not found"
-                )
+                raise StructuredAPIError(status_code=status.HTTP_401_UNAUTHORIZED, error_code="USER_NOT_FOUND", message="User not found")
             return CurrentUser(user.id, user.email, "admin" if getattr(user, "is_admin", False) else "user")
         finally:
             db.close()
@@ -246,10 +235,7 @@ async def get_current_user(
     if api_key:
         
         if "." not in api_key:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid API key format"
-            )
+            raise StructuredAPIError(status_code=status.HTTP_401_UNAUTHORIZED, error_code="INVALID_API_KEY_FORMAT", message="Invalid API key format")
 
         key_id, secret = api_key.split(".", 1)
 
@@ -260,22 +246,13 @@ async def get_current_user(
             ).first()
 
             if not key_record:
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="Invalid API key"
-                )
+                raise StructuredAPIError(status_code=status.HTTP_401_UNAUTHORIZED, error_code="INVALID_API_KEY", message="Invalid API key")
 
             if not key_record.is_valid():
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="API key has expired"
-                )
+                raise StructuredAPIError(status_code=status.HTTP_401_UNAUTHORIZED, error_code="API_KEY_EXPIRED", message="API key has expired")
 
             if not verify_api_key(secret, key_record.key_salt, key_record.key_hash):
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="Invalid API key"
-                )
+                raise StructuredAPIError(status_code=status.HTTP_401_UNAUTHORIZED, error_code="INVALID_API_KEY", message="Invalid API key")
 
             # Check if linked to a database user
             if key_record.user_id:
@@ -328,18 +305,12 @@ async def get_current_user_optional(
 async def get_admin_user(user: CurrentUser = Depends(get_current_user)) -> CurrentUser:
     """Verify user is admin"""
     if user.role != "admin":
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Admin access required"
-        )
+        raise StructuredAPIError(status_code=status.HTTP_403_FORBIDDEN, error_code="ADMIN_ACCESS_REQUIRED", message="Admin access required")
     return user
 
 
 async def get_attorney_user(user: CurrentUser = Depends(get_current_user)) -> CurrentUser:
     """Verify user is attorney or admin"""
     if user.role not in ["attorney", "admin"]:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Attorney access required"
-        )
+        raise StructuredAPIError(status_code=status.HTTP_403_FORBIDDEN, error_code="ATTORNEY_ACCESS_REQUIRED", message="Attorney access required")
     return user

--- a/api/csrf.py
+++ b/api/csrf.py
@@ -14,6 +14,7 @@ from fastapi import Request, HTTPException, status
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from api.config import get_settings
+from api.errors import StructuredAPIError, structured_error_response
 
 logger = structlog.get_logger(__name__)
 
@@ -22,9 +23,9 @@ CSRF_TOKEN_HEADER = "X-CSRF-Token"
 CSRF_COOKIE_NAME = "csrf_token"
 
 
-class CSRFError(HTTPException):
-    def __init__(self, detail: str = "CSRF validation failed"):
-        super().__init__(status_code=status.HTTP_403_FORBIDDEN, detail=detail)
+class CSRFError(StructuredAPIError):
+    def __init__(self, error_code: str, detail: str = "CSRF validation failed"):
+        super().__init__(status_code=status.HTTP_403_FORBIDDEN, error_code=error_code, message=detail)
 
 
 def generate_csrf_token() -> str:
@@ -96,20 +97,23 @@ def validate_csrf_request(
 
     if not is_same_origin(request, allowed_hosts):
         logger.warning("csrf_cross_origin_rejected", origin=origin, path=str(request.url.path))
-        raise CSRFError(detail="Cross-origin requests not allowed")
+        raise CSRFError(error_code="CSRF_CROSS_ORIGIN_REJECTED", detail="Cross-origin requests not allowed")
 
     if require_token:
         token = request.headers.get(CSRF_TOKEN_HEADER) or request.headers.get(CSRF_TOKEN_HEADER.lower())
         cookie_token = request.cookies.get(CSRF_COOKIE_NAME)
         if not token:
             logger.warning("csrf_missing_token", path=str(request.url.path))
-            raise CSRFError(detail=f"Missing CSRF token. Include '{CSRF_TOKEN_HEADER}' header.")
+            raise CSRFError(
+                error_code="CSRF_MISSING_TOKEN",
+                detail=f"Missing CSRF token. Include '{CSRF_TOKEN_HEADER}' header.",
+            )
         if not cookie_token:
             logger.warning("csrf_missing_cookie", path=str(request.url.path))
-            raise CSRFError(detail="Missing CSRF cookie.")
+            raise CSRFError(error_code="CSRF_MISSING_COOKIE", detail="Missing CSRF cookie.")
         if not secrets.compare_digest(token, cookie_token):
             logger.warning("csrf_token_mismatch", path=str(request.url.path))
-            raise CSRFError(detail="CSRF token mismatch.")
+            raise CSRFError(error_code="CSRF_TOKEN_MISMATCH", detail="CSRF token mismatch.")
 
 
 class CSRFProtectionMiddleware(BaseHTTPMiddleware):
@@ -143,16 +147,20 @@ class CSRFProtectionMiddleware(BaseHTTPMiddleware):
                 # If there's an Origin header, check same-origin and validate CSRF token
                 if not is_same_origin(request, self.allowed_hosts):
                     logger.warning("csrf_cross_origin_blocked", origin=origin, path=path)
-                    return JSONResponse(
+                    return structured_error_response(
                         status_code=status.HTTP_403_FORBIDDEN,
-                        content={"detail": "Cross-origin request blocked"},
+                        error_code="CSRF_CROSS_ORIGIN_BLOCKED",
+                        message="Cross-origin request blocked",
+                        request=request,
                     )
                 try:
                     validate_csrf_request(request, allowed_hosts=self.allowed_hosts)
                 except CSRFError as exc:
-                    return JSONResponse(
+                    return structured_error_response(
                         status_code=exc.status_code,
-                        content={"detail": exc.detail},
+                        error_code=exc.error_code,
+                        message=exc.message,
+                        request=request,
                     )
 
         # 2. Proceed with the request

--- a/api/errors.py
+++ b/api/errors.py
@@ -1,0 +1,72 @@
+"""Shared structured API error helpers."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from observability.instrumentation import generate_correlation_id
+
+
+class StructuredAPIError(HTTPException):
+    """HTTP exception that carries a standard error code."""
+
+    def __init__(self, status_code: int, error_code: str, message: str):
+        super().__init__(status_code=status_code, detail=message)
+        self.error_code = error_code
+        self.message = message
+
+
+def get_request_id(request: Optional[Request] = None, fallback: Optional[str] = None) -> str:
+    if fallback:
+        return fallback
+
+    if request is not None:
+        request_id = getattr(request.state, "request_id", None)
+        if request_id:
+            return request_id
+
+        for header_name in ("X-Request-Id", "X-Correlation-Id"):
+            header_value = request.headers.get(header_name)
+            if header_value:
+                return header_value
+
+    return generate_correlation_id()
+
+
+def build_error_payload(error_code: str, message: str, request_id: str) -> dict[str, str]:
+    return {
+        "error_code": error_code,
+        "message": message,
+        "request_id": request_id,
+    }
+
+
+def structured_error_response(
+    status_code: int,
+    error_code: str,
+    message: str,
+    request: Optional[Request] = None,
+    request_id: Optional[str] = None,
+) -> JSONResponse:
+    resolved_request_id = get_request_id(request, request_id)
+    return JSONResponse(
+        status_code=status_code,
+        content=build_error_payload(error_code, message, resolved_request_id),
+        headers={"X-Request-Id": resolved_request_id},
+    )
+
+
+async def structured_api_error_handler(request: Request, exc: StructuredAPIError) -> JSONResponse:
+    return structured_error_response(
+        status_code=exc.status_code,
+        error_code=exc.error_code,
+        message=exc.message,
+        request=request,
+    )
+
+
+def register_structured_error_handlers(app) -> None:
+    app.add_exception_handler(StructuredAPIError, structured_api_error_handler)

--- a/api/main.py
+++ b/api/main.py
@@ -16,6 +16,7 @@ from fastapi import status
 import structlog
 
 from api.config import get_settings
+from api.errors import StructuredAPIError, register_structured_error_handlers, structured_error_response
 from api.middlewares import register_middlewares
 from api.csrf import CSRFProtectionMiddleware
 from api.limiter import cleanup_limiter
@@ -151,6 +152,7 @@ def create_app() -> FastAPI:
 
     # Add middleware through a single registration entry to preserve order.
     register_middlewares(app)
+    register_structured_error_handlers(app)
 
     if _GRAPHQL_ROUTER is not None:
         app.include_router(
@@ -238,12 +240,11 @@ def create_app() -> FastAPI:
             path=request.url.path,
             detail=exc.detail
         )
-        return JSONResponse(
+        return structured_error_response(
             status_code=exc.status_code,
-            content={
-                "error_code": "VALIDATION_ERROR",
-                "message": exc.detail
-            }
+            error_code="VALIDATION_ERROR",
+            message=exc.detail,
+            request=request,
         )
     
     @app.exception_handler(PayloadTooLargeError)
@@ -254,12 +255,27 @@ def create_app() -> FastAPI:
             path=request.url.path,
             detail=exc.detail
         )
-        return JSONResponse(
+        return structured_error_response(
             status_code=exc.status_code,
-            content={
-                "error_code": "PAYLOAD_TOO_LARGE",
-                "message": exc.detail
-            }
+            error_code="PAYLOAD_TOO_LARGE",
+            message=exc.detail,
+            request=request,
+        )
+
+    @app.exception_handler(StructuredAPIError)
+    async def structured_api_error_handler(request: Request, exc: StructuredAPIError):
+        """Handle structured security errors from auth and CSRF helpers."""
+        logger.warning(
+            "structured_api_error",
+            path=request.url.path,
+            error_code=exc.error_code,
+            detail=exc.message,
+        )
+        return structured_error_response(
+            status_code=exc.status_code,
+            error_code=exc.error_code,
+            message=exc.message,
+            request=request,
         )
     
     # ========================================================================

--- a/api/middleware.py
+++ b/api/middleware.py
@@ -11,9 +11,9 @@ from typing import Callable
 
 import structlog
 from fastapi import HTTPException, Request, status
-from fastapi.responses import JSONResponse
 
 from api.config import get_settings
+from api.errors import structured_error_response
 from api.middlewares.idempotency import http_idempotency_manager, idempotency_middleware, is_safe_to_cache
 from api.middlewares.rate_limit import rate_limit_middleware
 from api.middlewares.request_size import request_size_limit_middleware
@@ -69,12 +69,11 @@ async def error_handling_middleware(request: Request, call_next: Callable):
         )
         record_api_error(request.url.path, exc)
         capture_exception(exc, path=request.url.path, method=request.method)
-        return JSONResponse(
+        return structured_error_response(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            content={
-                "error_code": "INTERNAL_SERVER_ERROR",
-                "message": "An internal error occurred",
-            },
+            error_code="INTERNAL_SERVER_ERROR",
+            message="An internal error occurred",
+            request=request,
         )
 
 

--- a/tests/test_api_key_security.py
+++ b/tests/test_api_key_security.py
@@ -23,6 +23,7 @@ from api.auth import (
     CurrentUser,
     verify_api_key,
 )
+from api.errors import register_structured_error_handlers
 import api.auth
 import database
 import db.session as db_session_module
@@ -56,6 +57,7 @@ def setup_database(monkeypatch):
 
 # Test application wrapping get_current_user dependency
 app = FastAPI()
+register_structured_error_handlers(app)
 
 
 @app.get("/protected")
@@ -122,14 +124,20 @@ def test_api_key_invalid_format(setup_database):
     # Missing period delimiter format
     response = client.get("/protected", headers={"Authorization": "Bearer key_invalidformat"})
     assert response.status_code == 401
-    assert "Invalid API key format" in response.json()["detail"]
+    payload = response.json()
+    assert payload["error_code"] == "INVALID_API_KEY_FORMAT"
+    assert "Invalid API key format" in payload["message"]
+    assert payload["request_id"]
 
 
 def test_api_key_nonexistent_key_id(setup_database):
     # Prefix key_id is not in DB
     response = client.get("/protected", headers={"Authorization": "Bearer key_nonexistent.secretstuff"})
     assert response.status_code == 401
-    assert "Invalid API key" in response.json()["detail"]
+    payload = response.json()
+    assert payload["error_code"] == "INVALID_API_KEY"
+    assert "Invalid API key" in payload["message"]
+    assert payload["request_id"]
 
 
 def test_api_key_incorrect_secret(setup_database):
@@ -141,7 +149,10 @@ def test_api_key_incorrect_secret(setup_database):
     bad_key = f"{key_id}.wrongsecret"
     response = client.get("/protected", headers={"Authorization": f"Bearer {bad_key}"})
     assert response.status_code == 401
-    assert "Invalid API key" in response.json()["detail"]
+    payload = response.json()
+    assert payload["error_code"] == "INVALID_API_KEY"
+    assert "Invalid API key" in payload["message"]
+    assert payload["request_id"]
 
 
 def test_api_key_expired(setup_database):
@@ -166,4 +177,7 @@ def test_api_key_expired(setup_database):
     combined_key = f"{key_id}.{secret}"
     response = client.get("/protected", headers={"Authorization": f"Bearer {combined_key}"})
     assert response.status_code == 401
-    assert "API key has expired" in response.json()["detail"]
+    payload = response.json()
+    assert payload["error_code"] == "API_KEY_EXPIRED"
+    assert "API key has expired" in payload["message"]
+    assert payload["request_id"]

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -58,7 +58,10 @@ def test_post_with_origin_but_no_cookie_or_header_fails():
     client.cookies.clear()
     response = client.post("/test-post", headers={"Origin": "http://localhost"})
     assert response.status_code == 403
-    assert "Missing CSRF token" in response.json()["detail"]
+    payload = response.json()
+    assert payload["error_code"] == "CSRF_MISSING_TOKEN"
+    assert "Missing CSRF token" in payload["message"]
+    assert payload["request_id"]
 
 def test_post_with_origin_and_header_but_no_cookie_fails():
     """Test that a request with header but no cookie fails."""
@@ -69,7 +72,10 @@ def test_post_with_origin_and_header_but_no_cookie_fails():
     }
     response = client.post("/test-post", headers=headers)
     assert response.status_code == 403
-    assert "Missing CSRF cookie" in response.json()["detail"]
+    payload = response.json()
+    assert payload["error_code"] == "CSRF_MISSING_COOKIE"
+    assert "Missing CSRF cookie" in payload["message"]
+    assert payload["request_id"]
 
 def test_post_with_origin_and_mismatched_tokens_fails():
     """Test that mismatched cookie and header values fail."""
@@ -81,7 +87,10 @@ def test_post_with_origin_and_mismatched_tokens_fails():
     client.cookies.set(CSRF_COOKIE_NAME, "different-cookie-token")
     response = client.post("/test-post", headers=headers)
     assert response.status_code == 403
-    assert "CSRF token mismatch" in response.json()["detail"]
+    payload = response.json()
+    assert payload["error_code"] == "CSRF_TOKEN_MISMATCH"
+    assert "CSRF token mismatch" in payload["message"]
+    assert payload["request_id"]
     client.cookies.clear()
 
 def test_post_with_matching_tokens_succeeds():


### PR DESCRIPTION
Standardized the security-side error payloads around a shared schema in errors.py. Auth now raises structured exceptions with stable error codes instead of plain detail strings in auth.py, CSRF middleware returns the same shape in csrf.py, and the FastAPI app registers the shared handler and routes validation/payload-too-large errors through the same formatter in main.py.

Updated the focused tests to assert error_code, message, and request_id in test_csrf.py and test_api_key_security.py. Validation passed for pytest test_csrf.py test_api_key_security.py -q. A broader smoke run of test_api_auth_flow.py still fails here because the existing rate limiter is trying to use Redis and returns 429s; that looks separate from this payload-format change.


closes #816