### PR TITLE
fix: add security headers to prevent Clickjacking and MIME sniffing

### DIFF
--- a/api/middleware.py
+++ b/api/middleware.py
@@ -373,6 +373,9 @@ async def add_correlation_id_middleware(request: Request, call_next: Callable):
     response = await call_next(request)
     response.headers["X-Correlation-Id"] = correlation_id
     response.headers["X-Request-Id"] = correlation_id
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
     return response
 
 


### PR DESCRIPTION
This PR resolves critical backend vulnerabilities as part of the NSoC level 3 audit assignment. Added \X-Frame-Options\ to DENY and \X-Content-Type-Options\ to \
osniff\, along with \Strict-Transport-Security\ headers in the middleware to prevent Clickjacking and MIME-type sniffing. Fixes #851