### PR TITLE
Replace asyncio.run(...) fallback with a safer event-loop strategy

### DIFF
--- a/services/timeline_realtime.py
+++ b/services/timeline_realtime.py
@@ -59,3 +59,24 @@ class TimelineRealtimeBus:
 
 
 timeline_realtime_bus = TimelineRealtimeBus()
+
+
+def publish_timeline_event_best_effort(payload: Dict[str, Any]) -> None:
+    """Publish a timeline event without depending on the caller's loop state."""
+    case_id = payload["case_id"]
+    publish_coro = timeline_realtime_bus.publish(case_id=case_id, payload=payload)
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop is not None:
+        loop.create_task(publish_coro)
+        return
+
+    fallback_loop = asyncio.new_event_loop()
+    try:
+        fallback_loop.run_until_complete(publish_coro)
+    finally:
+        fallback_loop.close()

--- a/services/timeline_service.py
+++ b/services/timeline_service.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional
 from sqlalchemy.orm import Session
 
 from db.models import CaseDocument, CaseDeadline, CaseTimeline, NotificationLog
-from services.timeline_realtime import timeline_realtime_bus
+from services.timeline_realtime import publish_timeline_event_best_effort
 
 
 class TimelineService:
@@ -35,35 +35,19 @@ class TimelineService:
         # Publish realtime update to connected websocket clients (case-scoped)
         # Fire-and-forget: timeline_realtime_bus is in-memory, so async scheduling
         # keeps DB write latency low.
+        payload = {
+            "type": "timeline_event",
+            "case_id": case_id,
+            "event_type": event.event_type,
+            "description": event.description,
+            "timestamp": event.event_date.isoformat(),
+            "metadata": event.event_metadata or {},
+            "event_id": event.id,
+        }
         try:
-            payload = {
-                "type": "timeline_event",
-                "case_id": case_id,
-                "event_type": event.event_type,
-                "description": event.description,
-                "timestamp": event.event_date.isoformat(),
-                "metadata": event.event_metadata or {},
-                "event_id": event.id,
-            }
-            import asyncio
-            asyncio.get_running_loop().create_task(
-                timeline_realtime_bus.publish(case_id=case_id, payload=payload)
-            )
-        except RuntimeError:
-            # No running loop (e.g., during sync unit tests). Emit best-effort.
-            try:
-                import asyncio
-                asyncio.run(timeline_realtime_bus.publish(case_id=case_id, payload={
-                    "type": "timeline_event",
-                    "case_id": case_id,
-                    "event_type": event.event_type,
-                    "description": event.description,
-                    "timestamp": event.event_date.isoformat(),
-                    "metadata": event.event_metadata or {},
-                    "event_id": event.id,
-                }))
-            except Exception:
-                pass
+            publish_timeline_event_best_effort(payload)
+        except Exception:
+            pass
 
         return event
 


### PR DESCRIPTION
Refactored the timeline publish path so the event payload is built once in timeline_service.py and handed to a new helper in timeline_realtime.py. The helper now uses the running loop when one exists, otherwise it creates a short-lived event loop with asyncio.new_event_loop() and closes it explicitly instead of calling asyncio.run().

Validation passed at the syntax level with py_compile on both edited files. 


closes #876