### PR TITLE
Made TimelineRealtimeBus lifecycle-safe

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -135,6 +135,12 @@ def create_app() -> FastAPI:
         yield
         
         await cleanup_limiter()
+        try:
+            from services.timeline_realtime import timeline_realtime_bus
+
+            await timeline_realtime_bus.close()
+        except Exception:
+            pass
         logger.info("API Shutting down")
     
     app = FastAPI(

--- a/services/timeline_realtime.py
+++ b/services/timeline_realtime.py
@@ -59,3 +59,24 @@ class TimelineRealtimeBus:
 
 
 timeline_realtime_bus = TimelineRealtimeBus()
+
+
+def publish_timeline_event_best_effort(payload: Dict[str, Any]) -> None:
+    """Publish a timeline event without depending on the caller's loop state."""
+    case_id = payload["case_id"]
+    publish_coro = timeline_realtime_bus.publish(case_id=case_id, payload=payload)
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop is not None:
+        loop.create_task(publish_coro)
+        return
+
+    fallback_loop = asyncio.new_event_loop()
+    try:
+        fallback_loop.run_until_complete(publish_coro)
+    finally:
+        fallback_loop.close()

--- a/services/timeline_realtime.py
+++ b/services/timeline_realtime.py
@@ -39,9 +39,20 @@ class TimelineRealtimeBus:
         return q
 
     async def unsubscribe(self, case_id: int, q: asyncio.Queue[str]) -> None:
-        channel = await self._get_or_create_channel(case_id)
+        async with self._global_lock:
+            channel = self._channels.get(case_id)
+            if channel is None:
+                return
         async with channel.lock:
             channel.connections.discard(q)
+            if not channel.connections:
+                async with self._global_lock:
+                    if self._channels.get(case_id) is channel:
+                        del self._channels[case_id]
+
+    async def close(self) -> None:
+        async with self._global_lock:
+            self._channels.clear()
 
     async def publish(self, case_id: int, payload: Dict[str, Any]) -> None:
         channel = await self._get_or_create_channel(case_id)

--- a/services/timeline_service.py
+++ b/services/timeline_service.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional
 from sqlalchemy.orm import Session
 
 from db.models import CaseDocument, CaseDeadline, CaseTimeline, NotificationLog
-from services.timeline_realtime import timeline_realtime_bus
+from services.timeline_realtime import publish_timeline_event_best_effort
 
 
 class TimelineService:
@@ -35,35 +35,19 @@ class TimelineService:
         # Publish realtime update to connected websocket clients (case-scoped)
         # Fire-and-forget: timeline_realtime_bus is in-memory, so async scheduling
         # keeps DB write latency low.
+        payload = {
+            "type": "timeline_event",
+            "case_id": case_id,
+            "event_type": event.event_type,
+            "description": event.description,
+            "timestamp": event.event_date.isoformat(),
+            "metadata": event.event_metadata or {},
+            "event_id": event.id,
+        }
         try:
-            payload = {
-                "type": "timeline_event",
-                "case_id": case_id,
-                "event_type": event.event_type,
-                "description": event.description,
-                "timestamp": event.event_date.isoformat(),
-                "metadata": event.event_metadata or {},
-                "event_id": event.id,
-            }
-            import asyncio
-            asyncio.get_running_loop().create_task(
-                timeline_realtime_bus.publish(case_id=case_id, payload=payload)
-            )
-        except RuntimeError:
-            # No running loop (e.g., during sync unit tests). Emit best-effort.
-            try:
-                import asyncio
-                asyncio.run(timeline_realtime_bus.publish(case_id=case_id, payload={
-                    "type": "timeline_event",
-                    "case_id": case_id,
-                    "event_type": event.event_type,
-                    "description": event.description,
-                    "timestamp": event.event_date.isoformat(),
-                    "metadata": event.event_metadata or {},
-                    "event_id": event.id,
-                }))
-            except Exception:
-                pass
+            publish_timeline_event_best_effort(payload)
+        except Exception:
+            pass
 
         return event
 

--- a/tests/test_timeline_realtime.py
+++ b/tests/test_timeline_realtime.py
@@ -1,0 +1,30 @@
+import asyncio
+
+from services.timeline_realtime import TimelineRealtimeBus
+
+
+def test_unsubscribe_removes_empty_channel():
+    bus = TimelineRealtimeBus()
+
+    async def scenario() -> None:
+        queue = await bus.subscribe(42)
+        assert 42 in bus._channels
+
+        await bus.unsubscribe(42, queue)
+        assert 42 not in bus._channels
+
+    asyncio.run(scenario())
+
+
+def test_close_clears_all_channels():
+    bus = TimelineRealtimeBus()
+
+    async def scenario() -> None:
+        await bus.subscribe(1)
+        await bus.subscribe(2)
+        assert set(bus._channels) == {1, 2}
+
+        await bus.close()
+        assert bus._channels == {}
+
+    asyncio.run(scenario())


### PR DESCRIPTION
Made the bus lifecycle-safe. `unsubscribe()` now removes a case channel when its last connection goes away in timeline_realtime.py, and the bus now has a `close()` method for shutdown cleanup in timeline_realtime.py. I also wired app lifespan shutdown to call it in main.py.

I added focused coverage for both behaviors in test_timeline_realtime.py and test_timeline_realtime.py.

Validation: `pytest test_timeline_realtime.py -q` passed.


closes #877