### PR TITLE
Introduce typed “event payload” models for timeline events

### DIFF
--- a/services/timeline_realtime.py
+++ b/services/timeline_realtime.py
@@ -9,7 +9,7 @@ from core.timeline_payloads import TimelineEventPayload
 
 @dataclass
 class _CaseChannel:
-    connections: Set["asyncio.Queue[Dict[str, Any]]"] = field(default_factory=set)
+    connections: Set[tuple["asyncio.Queue[Dict[str, Any]]", asyncio.AbstractEventLoop]] = field(default_factory=set)
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
@@ -35,8 +35,9 @@ class TimelineRealtimeBus:
     async def subscribe(self, case_id: int) -> asyncio.Queue[Dict[str, Any]]:
         channel = await self._get_or_create_channel(case_id)
         q: asyncio.Queue[Dict[str, Any]] = asyncio.Queue()
+        loop = asyncio.get_running_loop()
         async with channel.lock:
-            channel.connections.add(q)
+            channel.connections.add((q, loop))
         return q
 
     async def unsubscribe(self, case_id: int, q: asyncio.Queue[Dict[str, Any]]) -> None:
@@ -45,7 +46,7 @@ class TimelineRealtimeBus:
             if channel is None:
                 return
         async with channel.lock:
-            channel.connections.discard(q)
+            channel.connections = {subscriber for subscriber in channel.connections if subscriber[0] is not q}
             if not channel.connections:
                 async with self._global_lock:
                     if self._channels.get(case_id) is channel:
@@ -63,12 +64,15 @@ class TimelineRealtimeBus:
             targets = list(channel.connections)
 
         # fan-out outside lock
-        for q in targets:
-            try:
-                q.put_nowait(message)
-            except asyncio.QueueFull:
-                # drop message for that slow consumer
-                pass
+        for q, loop in targets:
+            def _deliver() -> None:
+                try:
+                    q.put_nowait(message)
+                except asyncio.QueueFull:
+                    # drop message for that slow consumer
+                    pass
+
+            loop.call_soon_threadsafe(_deliver)
 
 
 timeline_realtime_bus = TimelineRealtimeBus()

--- a/services/timeline_service.py
+++ b/services/timeline_service.py
@@ -37,20 +37,16 @@ class TimelineService:
         # Publish realtime update to connected websocket clients (case-scoped)
         # Fire-and-forget: timeline_realtime_bus is in-memory, so async scheduling
         # keeps DB write latency low.
-        payload = {
-            "type": "timeline_event",
-            "case_id": case_id,
-            "event_type": event.event_type,
-            "description": event.description,
-            "timestamp": event.event_date,
-            "metadata": event.event_metadata or {},
-            "event_id": event.id,
-        }
-        try:
-            validated_payload = TimelineEventPayload.model_validate(payload)
-            publish_timeline_event_best_effort(validated_payload.model_dump(mode="json"))
-        except Exception:
-            pass
+        payload = TimelineEventPayload(
+            type="timeline_event",
+            case_id=case_id,
+            event_type=event.event_type,
+            description=event.description,
+            timestamp=event.event_date,
+            metadata=event.event_metadata or {},
+            event_id=event.id,
+        )
+        publish_timeline_event_best_effort(payload.model_dump(mode="json"))
 
         return event
 

--- a/tests/test_case_timeline_websocket.py
+++ b/tests/test_case_timeline_websocket.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime, timezone
 
 import pytest
 from fastapi.testclient import TestClient
@@ -68,24 +69,33 @@ def test_case_timeline_ws_subscribed_and_forwards_event(mock_verify_token, clien
 
         # Publish directly into the realtime bus. This avoids DB/session coupling in the websocket test.
         from services.timeline_realtime import timeline_realtime_bus
-        timeline_payload = {
-            "type": "timeline_event",
-            "case_id": case_id,
-            "event_type": "deadline_created",
-            "description": "Manual deadline added",
-            "timestamp": "2023-01-01T00:00:00+00:00",
-            "metadata": {"deadline_id": 999},
-            "event_id": 555,
-        }
+        timeline_payload = TimelineEventPayload(
+            type="timeline_event",
+            case_id=case_id,
+            event_type="deadline_created",
+            description="Manual deadline added",
+            timestamp=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            metadata={"deadline_id": 999},
+            event_id=555,
+        )
 
         # timeline_realtime_bus.publish() is async; TestClient is sync,
         # so we run a short event-loop to publish.
         import asyncio
 
-        asyncio.run(timeline_realtime_bus.publish(case_id=case_id, payload=timeline_payload))
+        asyncio.run(timeline_realtime_bus.publish(case_id=case_id, payload=timeline_payload.model_dump(mode="json")))
 
         msg = websocket.receive_json()
         validated = TimelineEventPayload.model_validate(msg)
+        assert set(validated.model_dump(mode="json")) == {
+            "type",
+            "case_id",
+            "event_type",
+            "description",
+            "timestamp",
+            "metadata",
+            "event_id",
+        }
         assert validated.type == "timeline_event"
         assert validated.case_id == case_id
         assert validated.event_type == "deadline_created"

--- a/tests/test_timeline_realtime.py
+++ b/tests/test_timeline_realtime.py
@@ -58,6 +58,24 @@ def test_publish_normalizes_datetimes_to_utc_iso():
 
         payload = await queue.get()
         validated = TimelineEventPayload.model_validate(payload)
+        assert set(TimelineEventPayload.model_fields) == {
+            "type",
+            "case_id",
+            "event_type",
+            "description",
+            "timestamp",
+            "metadata",
+            "event_id",
+        }
+        assert set(validated.model_dump(mode="json")) == {
+            "type",
+            "case_id",
+            "event_type",
+            "description",
+            "timestamp",
+            "metadata",
+            "event_id",
+        }
         assert validated.type == "timeline_event"
         assert validated.case_id == 7
         assert validated.event_type == "deadline_created"
@@ -67,6 +85,22 @@ def test_publish_normalizes_datetimes_to_utc_iso():
         assert validated.model_dump(mode="json")["metadata"]["nested_timestamp"] == "2026-05-22T10:31:00+00:00"
 
     asyncio.run(scenario())
+
+
+def test_timeline_event_payload_rejects_extra_fields():
+    with pytest.raises(ValidationError):
+        TimelineEventPayload.model_validate(
+            {
+                "type": "timeline_event",
+                "case_id": 7,
+                "event_type": "deadline_created",
+                "description": "Manual deadline added",
+                "timestamp": datetime(2026, 5, 22, 10, 30, tzinfo=timezone.utc),
+                "metadata": {},
+                "event_id": 555,
+                "unexpected": "value",
+            }
+        )
 
 
 def test_publish_rejects_invalid_payload_shape():


### PR DESCRIPTION
I changed timeline_service.py to build a `TimelineEventPayload` before publishing, so schema drift now fails fast instead of being swallowed. I also made timeline_realtime.py loop-safe by storing each subscriber’s event loop and delivering queued websocket messages with `call_soon_threadsafe`, which fixed the TestClient hang.

The tests now assert the exact payload shape in test_timeline_realtime.py and use the typed payload model in test_case_timeline_websocket.py.

Validation passed: pytest test_timeline_realtime.py test_case_timeline_websocket.py -q

closes #880