### PR TITLE
Add backpressure/metrics instead of silently dropping messages

### DIFF
--- a/api/routes/cases.py
+++ b/api/routes/cases.py
@@ -4,7 +4,7 @@ POST /api/v1/cases/search - Search for similar cases
 POST /api/v1/cases/similarity-feedback - Save similarity feedback
 GET /api/v1/cases/{id}/timeline - Get case timeline
 """
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException, status, Depends, UploadFile, File, Form, Request
 from sqlalchemy.orm import Session
@@ -33,6 +33,7 @@ from database import (
     Attachment,
 )
 from db.case_service import save_case_note_draft, publish_case_note, get_case_note_history
+from services.timeline_service import timeline_service as _timeline_service
 try:
     from celery_app import enqueue_task_from_http_request, process_case_document_upload_task
 except Exception:
@@ -274,6 +275,41 @@ def _build_query_signature(request: CaseSearchRequest) -> str:
     return "|".join(parts)
 
 
+def _timeline_event_to_api_event(event) -> CaseEvent:
+    metadata = event.event_metadata if isinstance(event.event_metadata, dict) else {}
+    documents = metadata.get("documents") if isinstance(metadata.get("documents"), list) else []
+    return CaseEvent(
+        date=event.event_date,
+        event_type=event.event_type,
+        description=event.description,
+        court=metadata.get("court"),
+        judge=metadata.get("judge"),
+        location=metadata.get("location"),
+        documents=documents,
+    )
+
+
+def _build_case_timeline_payload(case: Case, timeline_events) -> dict:
+    api_events = [_timeline_event_to_api_event(event) for event in timeline_events]
+    event_dates = [event.date for event in api_events]
+    if len(event_dates) >= 2:
+        duration_years = round((max(event_dates) - min(event_dates)).days / 365.25, 1)
+    else:
+        duration_years = 0.0
+
+    return {
+        "case_id": str(case.id),
+        "case_number": case.case_number,
+        "title": case.title or case.case_number,
+        "status": case.status.value if hasattr(case.status, "value") else str(case.status),
+        "created_at": case.created_at,
+        "updated_at": case.updated_at or case.created_at,
+        "events": api_events,
+        "total_events": len(api_events),
+        "duration_years": duration_years,
+    }
+
+
 
 @router.get(
     "/{case_id}/timeline",
@@ -282,74 +318,31 @@ def _build_query_signature(request: CaseSearchRequest) -> str:
 )
 async def get_case_timeline(
     case_id: str,
-    current_user: CurrentUser = Depends(get_current_user)
+    current_user: CurrentUser = Depends(get_current_user),
+    db: Session = Depends(get_db),
 ) -> CaseTimeline:
-    """Get case history and timeline"""
-    
+    """Get case history and timeline."""
     logger.info(
         "Retrieving case timeline",
         case_id=case_id,
-        user_id=current_user.user_id
+        user_id=current_user.user_id,
     )
-    
-    # Mock timeline data
-    base_date = datetime.now(timezone.utc) - timedelta(days=365)
-    events = [
-        CaseEvent(
-            date=base_date,
-            event_type="filing",
-            description="Case filed",
-            court="District Court",
-            location="New York, NY",
-            documents=["complaint.pdf"]
-        ),
-        CaseEvent(
-            date=base_date + timedelta(days=30),
-            event_type="hearing",
-            description="Initial hearing",
-            court="District Court",
-            judge="Judge Smith",
-            location="New York, NY"
-        ),
-        CaseEvent(
-            date=base_date + timedelta(days=90),
-            event_type="discovery",
-            description="Discovery period",
-            court="District Court",
-            location="New York, NY"
-        ),
-        CaseEvent(
-            date=base_date + timedelta(days=180),
-            event_type="hearing",
-            description="Motion hearing",
-            court="District Court",
-            judge="Judge Smith",
-            location="New York, NY"
-        ),
-        CaseEvent(
-            date=base_date + timedelta(days=365),
-            event_type="decision",
-            description="Court decision rendered",
-            court="District Court",
-            judge="Judge Smith",
-            location="New York, NY",
-            documents=["decision.pdf"]
-        ),
-    ]
 
-    timeline_payload = {
-        "case_id": case_id,
-        "case_number": "2023-CV-00001",
-        "title": "Example Case",
-        "status": "closed",
-        "created_at": base_date,
-        "updated_at": datetime.now(timezone.utc),
-        "events": events,
-        "total_events": len(events),
-        "duration_years": 1.0,
-    }
+    try:
+        case_id_int = int(case_id)
+        user_id_int = int(current_user.user_id)
+    except (ValueError, TypeError):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid case ID format")
 
-    return CaseTimeline.model_validate(timeline_payload)
+    case = db.query(Case).filter(Case.id == case_id_int).first()
+    if not case:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Case not found")
+
+    if case.user_id != user_id_int:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden: You do not own this case")
+
+    timeline_events = _timeline_service.get_case_timeline(db, case_id_int)
+    return CaseTimeline.model_validate(_build_case_timeline_payload(case, timeline_events))
 
 
 @router.get(

--- a/api/routes/cases.py
+++ b/api/routes/cases.py
@@ -58,6 +58,23 @@ def _build_case_summary_payload(case: Case, latest_doc: CaseDocument | None = No
     }
 
 
+def get_owned_case(case_id: str, current_user: CurrentUser, db: Session) -> Case:
+    try:
+        case_id_int = int(case_id)
+        user_id_int = int(current_user.user_id)
+    except (ValueError, TypeError):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid case ID format")
+
+    case = db.query(Case).filter(Case.id == case_id_int).first()
+    if not case:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Case not found")
+
+    if case.user_id != user_id_int:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden: You do not own this case")
+
+    return case
+
+
 @router.post(
     "/search",
     response_model=CaseSearchResponse,
@@ -320,20 +337,9 @@ async def get_case_timeline(
         user_id=current_user.user_id,
     )
 
-    try:
-        case_id_int = int(case_id)
-        user_id_int = int(current_user.user_id)
-    except (ValueError, TypeError):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid case ID format")
+    case = get_owned_case(case_id, current_user, db)
 
-    case = db.query(Case).filter(Case.id == case_id_int).first()
-    if not case:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Case not found")
-
-    if case.user_id != user_id_int:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden: You do not own this case")
-
-    timeline_events = _timeline_service.get_case_timeline(db, case_id_int)
+    timeline_events = _timeline_service.get_case_timeline(db, case.id)
     return CaseTimeline.model_validate(_build_case_timeline_payload(case, timeline_events))
 
 
@@ -353,37 +359,7 @@ async def get_case_details(
         case_id=case_id,
         user_id=current_user.user_id
     )
-    
-    try:
-        user_id_int = int(current_user.user_id)
-    except (ValueError, TypeError):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid user ID format"
-        )
-        
-    try:
-        case_id_int = int(case_id)
-    except (ValueError, TypeError):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid case ID format"
-        )
-        
-    case = db.query(Case).filter(Case.id == case_id_int).first()
-    
-    if not case:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Case not found"
-        )
-        
-    if case.user_id != user_id_int:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Forbidden: You do not own this case"
-        )
-        
+    case = get_owned_case(case_id, current_user, db)
     latest_docs = fetch_latest_documents_per_case(db, [case.id])
 
     return _build_case_summary_payload(case, latest_docs.get(case.id))
@@ -402,17 +378,9 @@ async def upload_case_document_endpoint(
     db: Session = Depends(get_db),
 ) -> dict:
     """Store an upload, create linked attachment/document rows, and queue OCR extraction."""
-    try:
-        case_id_int = int(case_id)
-        user_id_int = int(current_user.user_id)
-    except (ValueError, TypeError):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid ID format")
-
-    case = db.query(Case).filter(Case.id == case_id_int).first()
-    if not case:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Case not found")
-    if case.user_id != user_id_int:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden: You do not own this case")
+    case = get_owned_case(case_id, current_user, db)
+    case_id_int = case.id
+    user_id_int = int(current_user.user_id)
 
     allowed_extensions = {".pdf", ".png", ".jpg", ".jpeg", ".tif", ".tiff", ".bmp", ".webp"}
     allowed_mime_types = {
@@ -479,17 +447,9 @@ async def save_case_note_draft_endpoint(
     current_user: CurrentUser = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> dict:
-    try:
-        case_id_int = int(case_id)
-        user_id_int = int(current_user.user_id)
-    except (ValueError, TypeError):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid ID format")
-
-    case = db.query(Case).filter(Case.id == case_id_int).first()
-    if not case:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Case not found")
-    if case.user_id != user_id_int:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden: You do not own this case")
+    case = get_owned_case(case_id, current_user, db)
+    case_id_int = case.id
+    user_id_int = int(current_user.user_id)
 
     note = save_case_note_draft(
         db,
@@ -517,17 +477,9 @@ async def publish_case_note_endpoint(
     current_user: CurrentUser = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> dict:
-    try:
-        case_id_int = int(case_id)
-        user_id_int = int(current_user.user_id)
-    except (ValueError, TypeError):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid ID format")
-
-    case = db.query(Case).filter(Case.id == case_id_int).first()
-    if not case:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Case not found")
-    if case.user_id != user_id_int:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden: You do not own this case")
+    case = get_owned_case(case_id, current_user, db)
+    case_id_int = case.id
+    user_id_int = int(current_user.user_id)
 
     version = publish_case_note(
         db,
@@ -557,17 +509,9 @@ async def get_case_note_history_endpoint(
     current_user: CurrentUser = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> CaseNoteHistoryResponse:
-    try:
-        case_id_int = int(case_id)
-        user_id_int = int(current_user.user_id)
-    except (ValueError, TypeError):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid ID format")
-
-    case = db.query(Case).filter(Case.id == case_id_int).first()
-    if not case:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Case not found")
-    if case.user_id != user_id_int:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden: You do not own this case")
+    case = get_owned_case(case_id, current_user, db)
+    case_id_int = case.id
+    user_id_int = int(current_user.user_id)
 
     versions = get_case_note_history(db, case_id_int, user_id_int)
     return CaseNoteHistoryResponse(

--- a/api/routes/cases.py
+++ b/api/routes/cases.py
@@ -31,11 +31,8 @@ from database import (
     DocumentType,
     CaseDocument,
     Attachment,
-    save_case_note_draft,
-    publish_case_note,
-    get_case_note_history,
 )
-from case_manager import upload_case_document_file
+from db.case_service import save_case_note_draft, publish_case_note, get_case_note_history
 try:
     from celery_app import enqueue_task_from_http_request, process_case_document_upload_task
 except Exception:
@@ -45,6 +42,27 @@ from analytics_engine import CaseSimilarityCalculator
 
 router = APIRouter(prefix="/api/v1/cases", tags=["cases"])
 logger = structlog.get_logger(__name__)
+
+
+def _get_latest_case_document(case: Case) -> CaseDocument | None:
+    if not case.documents:
+        return None
+    return max(case.documents, key=lambda document: document.uploaded_at)
+
+
+def _build_case_summary_payload(case: Case, latest_doc: CaseDocument | None = None) -> dict:
+    if latest_doc is None:
+        latest_doc = _get_latest_case_document(case)
+
+    return {
+        "case_id": str(case.id),
+        "case_number": case.case_number,
+        "title": case.title or case.case_number,
+        "parties": ["Smith", "Jones"],  # Placeholder
+        "jurisdiction": case.jurisdiction,
+        "status": case.status.value if hasattr(case.status, 'value') else str(case.status),
+        "summary": latest_doc.summary if latest_doc else "",
+    }
 
 
 @router.post(
@@ -382,19 +400,9 @@ async def get_case_details(
         )
         
     latest_doc = None
-    if case.documents:
-        sorted_docs = sorted(case.documents, key=lambda d: d.uploaded_at, reverse=True)
-        latest_doc = sorted_docs[0]
-        
-    return {
-        "case_id": str(case.id),
-        "case_number": case.case_number,
-        "title": case.title or case.case_number,
-        "parties": ["Smith", "Jones"],  # Placeholder
-        "jurisdiction": case.jurisdiction,
-        "status": case.status.value if hasattr(case.status, 'value') else str(case.status),
-        "summary": latest_doc.summary if latest_doc else ""
-    }
+    latest_doc = _get_latest_case_document(case)
+
+    return _build_case_summary_payload(case, latest_doc)
 
 
 @router.post(
@@ -441,6 +449,8 @@ async def upload_case_document_endpoint(
     )
     await validate_file_upload_streaming(file, max_size=ValidationConfig.MAX_UPLOAD_SIZE)
     file_bytes = await file.read()
+
+    from case_manager import upload_case_document_file
 
     stored = upload_case_document_file(
         user_id=user_id_int,
@@ -636,20 +646,7 @@ async def list_cases(
     
     cases_list = []
     for c in cases:
-        latest_doc = None
-        if c.documents:
-            sorted_docs = sorted(c.documents, key=lambda d: d.uploaded_at, reverse=True)
-            latest_doc = sorted_docs[0]
-            
-        cases_list.append({
-            "case_id": str(c.id),
-            "case_number": c.case_number,
-            "title": c.title or c.case_number,
-            "parties": ["Smith", "Jones"],  # Placeholder
-            "jurisdiction": c.jurisdiction,
-            "status": c.status.value if hasattr(c.status, 'value') else str(c.status),
-            "summary": latest_doc.summary if latest_doc else ""
-        })
+        cases_list.append(_build_case_summary_payload(c))
         
     return {
         "total": total,

--- a/api/routes/cases.py
+++ b/api/routes/cases.py
@@ -33,6 +33,7 @@ from database import (
     Attachment,
 )
 from db.case_service import save_case_note_draft, publish_case_note, get_case_note_history
+from db.repositories.case_queries import fetch_latest_documents_per_case
 from services.timeline_service import timeline_service as _timeline_service
 try:
     from celery_app import enqueue_task_from_http_request, process_case_document_upload_task
@@ -45,16 +46,7 @@ router = APIRouter(prefix="/api/v1/cases", tags=["cases"])
 logger = structlog.get_logger(__name__)
 
 
-def _get_latest_case_document(case: Case) -> CaseDocument | None:
-    if not case.documents:
-        return None
-    return max(case.documents, key=lambda document: document.uploaded_at)
-
-
 def _build_case_summary_payload(case: Case, latest_doc: CaseDocument | None = None) -> dict:
-    if latest_doc is None:
-        latest_doc = _get_latest_case_document(case)
-
     return {
         "case_id": str(case.id),
         "case_number": case.case_number,
@@ -392,10 +384,9 @@ async def get_case_details(
             detail="Forbidden: You do not own this case"
         )
         
-    latest_doc = None
-    latest_doc = _get_latest_case_document(case)
+    latest_docs = fetch_latest_documents_per_case(db, [case.id])
 
-    return _build_case_summary_payload(case, latest_doc)
+    return _build_case_summary_payload(case, latest_docs.get(case.id))
 
 
 @router.post(
@@ -637,9 +628,11 @@ async def list_cases(
         .all()
     )
     
+    latest_docs = fetch_latest_documents_per_case(db, [c.id for c in cases])
+
     cases_list = []
     for c in cases:
-        cases_list.append(_build_case_summary_payload(c))
+        cases_list.append(_build_case_summary_payload(c, latest_docs.get(c.id)))
         
     return {
         "total": total,

--- a/database.py
+++ b/database.py
@@ -838,15 +838,20 @@ class CaseDocument(Base):
 
     id = Column(Integer, primary_key=True)
     case_id = Column(Integer, ForeignKey("cases.id", ondelete="CASCADE"), nullable=False, index=True)
+    source_attachment_id = Column(Integer, ForeignKey("attachments.id", ondelete="SET NULL"), nullable=True, index=True)
     document_type = Column(SQLEnum(DocumentType), nullable=False)
     document_content = Column(Text, nullable=True)  # Extracted text from PDF
     file_path = Column(String(255), nullable=True)  # Optional: path to stored PDF
     uploaded_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), nullable=False)
     summary = Column(Text, nullable=True)  # LLM-generated 3-bullet summary
     remedies = Column(JSON, nullable=True)  # JSON: appeal info, deadlines, costs
+    extracted_metadata = Column(JSON, nullable=True)
+    extraction_method = Column(String(50), nullable=True)
+    ocr_used = Column(Boolean, default=False, nullable=False)
 
     # Relationships
     case = relationship("Case", back_populates="documents")
+    attachment = relationship("Attachment", foreign_keys=[source_attachment_id])
 
     def __repr__(self):
         return f"<CaseDocument(case_id={self.case_id}, type={self.document_type})>"

--- a/db/repositories/case_queries.py
+++ b/db/repositories/case_queries.py
@@ -26,25 +26,29 @@ def fetch_latest_documents_per_case(db: Session, case_ids: List[int]) -> Dict[in
     if not case_ids:
         return {}
     
-    # Subquery to find the max uploaded_at per case
-    subquery = (
+    # Rank documents per case in SQL so the latest row can be selected without
+    # Python-side sorting. Tie-break on id for deterministic results.
+    ranked_docs = (
         db.query(
-            CaseDocument.case_id,
-            func.max(CaseDocument.uploaded_at).label("max_uploaded_at"),
+            CaseDocument.id.label("doc_id"),
+            CaseDocument.case_id.label("case_id"),
+            func.row_number()
+            .over(
+                partition_by=CaseDocument.case_id,
+                order_by=(CaseDocument.uploaded_at.desc(), CaseDocument.id.desc()),
+            )
+            .label("row_number"),
         )
         .filter(CaseDocument.case_id.in_(case_ids))
-        .group_by(CaseDocument.case_id)
         .subquery()
     )
     
-    # Join to get the actual documents
-    latest_docs = db.query(CaseDocument).join(
-        subquery,
-        and_(
-            CaseDocument.case_id == subquery.c.case_id,
-            CaseDocument.uploaded_at == subquery.c.max_uploaded_at,
-        ),
-    ).all()
+    latest_docs = (
+        db.query(CaseDocument)
+        .join(ranked_docs, CaseDocument.id == ranked_docs.c.doc_id)
+        .filter(ranked_docs.c.row_number == 1)
+        .all()
+    )
     
     # Map to dict
     result: Dict[int, CaseDocument] = {}

--- a/services/timeline_realtime.py
+++ b/services/timeline_realtime.py
@@ -1,16 +1,24 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import threading
 from dataclasses import dataclass, field
 from typing import Any, Dict, Set
 
+import structlog
+
 from core.timeline_payloads import TimelineEventPayload
+
+
+logger = structlog.get_logger(__name__)
 
 
 @dataclass
 class _CaseChannel:
     connections: Set[tuple["asyncio.Queue[Dict[str, Any]]", asyncio.AbstractEventLoop]] = field(default_factory=set)
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    dropped_messages: int = 0
 
 
 class TimelineRealtimeBus:
@@ -22,9 +30,66 @@ class TimelineRealtimeBus:
       the given case_id.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, queue_maxsize: int = 100) -> None:
+        self._queue_maxsize = max(1, int(queue_maxsize))
         self._channels: Dict[int, _CaseChannel] = {}
         self._global_lock = asyncio.Lock()
+        self._drop_lock = threading.Lock()
+        self._dropped_messages_total = 0
+
+    @property
+    def queue_maxsize(self) -> int:
+        return self._queue_maxsize
+
+    @property
+    def dropped_messages_total(self) -> int:
+        with self._drop_lock:
+            return self._dropped_messages_total
+
+    def _record_drop(self, case_id: int, channel: _CaseChannel) -> None:
+        with self._drop_lock:
+            self._dropped_messages_total += 1
+            total_dropped = self._dropped_messages_total
+
+        channel.dropped_messages += 1
+        logger.warning(
+            "timeline_realtime_queue_dropped",
+            case_id=case_id,
+            queue_maxsize=self._queue_maxsize,
+            dropped_messages=1,
+            total_dropped_messages=total_dropped,
+            case_dropped_messages=channel.dropped_messages,
+            policy="drop_oldest_keep_latest",
+        )
+
+    @staticmethod
+    def _deliver_message(
+        *,
+        queue: asyncio.Queue[Dict[str, Any]],
+        message: Dict[str, Any],
+        case_id: int,
+        channel: _CaseChannel,
+        record_drop,
+    ) -> None:
+        if queue.full():
+            try:
+                queue.get_nowait()
+            except asyncio.QueueEmpty:
+                pass
+            else:
+                record_drop(case_id, channel)
+
+        try:
+            queue.put_nowait(message)
+        except asyncio.QueueFull:
+            # If another producer filled the queue between eviction and put,
+            # drop the oldest item once more and keep the newest payload.
+            try:
+                queue.get_nowait()
+            except asyncio.QueueEmpty:
+                return
+            record_drop(case_id, channel)
+            queue.put_nowait(message)
 
     async def _get_or_create_channel(self, case_id: int) -> _CaseChannel:
         async with self._global_lock:
@@ -34,7 +99,7 @@ class TimelineRealtimeBus:
 
     async def subscribe(self, case_id: int) -> asyncio.Queue[Dict[str, Any]]:
         channel = await self._get_or_create_channel(case_id)
-        q: asyncio.Queue[Dict[str, Any]] = asyncio.Queue()
+        q: asyncio.Queue[Dict[str, Any]] = asyncio.Queue(maxsize=self._queue_maxsize)
         loop = asyncio.get_running_loop()
         async with channel.lock:
             channel.connections.add((q, loop))
@@ -60,22 +125,28 @@ class TimelineRealtimeBus:
         channel = await self._get_or_create_channel(case_id)
         validated_payload = TimelineEventPayload.model_validate(payload)
         message = validated_payload.model_dump(mode="json")
+        current_loop = asyncio.get_running_loop()
         async with channel.lock:
             targets = list(channel.connections)
 
         # fan-out outside lock
         for q, loop in targets:
-            def _deliver() -> None:
-                try:
-                    q.put_nowait(message)
-                except asyncio.QueueFull:
-                    # drop message for that slow consumer
-                    pass
+            deliver = lambda q=q, loop=loop: self._deliver_message(
+                queue=q,
+                message=message,
+                case_id=case_id,
+                channel=channel,
+                record_drop=self._record_drop,
+            )
 
-            loop.call_soon_threadsafe(_deliver)
+            if loop is current_loop:
+                deliver()
+            else:
+                loop.call_soon_threadsafe(deliver)
 
 
-timeline_realtime_bus = TimelineRealtimeBus()
+timeline_queue_maxsize = int(os.getenv("TIMELINE_REALTIME_QUEUE_MAXSIZE", "100"))
+timeline_realtime_bus = TimelineRealtimeBus(queue_maxsize=timeline_queue_maxsize)
 
 
 def publish_timeline_event_best_effort(payload: Dict[str, Any]) -> None:

--- a/services/timeline_realtime.py
+++ b/services/timeline_realtime.py
@@ -9,7 +9,7 @@ from core.timeline_payloads import TimelineEventPayload
 
 @dataclass
 class _CaseChannel:
-    connections: Set["asyncio.Queue[Dict[str, Any]]"] = field(default_factory=set)
+    connections: Set[tuple["asyncio.Queue[Dict[str, Any]]", asyncio.AbstractEventLoop]] = field(default_factory=set)
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
@@ -35,8 +35,9 @@ class TimelineRealtimeBus:
     async def subscribe(self, case_id: int) -> asyncio.Queue[Dict[str, Any]]:
         channel = await self._get_or_create_channel(case_id)
         q: asyncio.Queue[Dict[str, Any]] = asyncio.Queue()
+        loop = asyncio.get_running_loop()
         async with channel.lock:
-            channel.connections.add(q)
+            channel.connections.add((q, loop))
         return q
 
     async def unsubscribe(self, case_id: int, q: asyncio.Queue[Dict[str, Any]]) -> None:
@@ -45,7 +46,7 @@ class TimelineRealtimeBus:
             if channel is None:
                 return
         async with channel.lock:
-            channel.connections.discard(q)
+            channel.connections = {subscriber for subscriber in channel.connections if subscriber[0] is not q}
             if not channel.connections:
                 async with self._global_lock:
                     if self._channels.get(case_id) is channel:
@@ -63,12 +64,15 @@ class TimelineRealtimeBus:
             targets = list(channel.connections)
 
         # fan-out outside lock
-        for q in targets:
-            try:
-                q.put_nowait(message)
-            except asyncio.QueueFull:
-                # drop message for that slow consumer
-                pass
+        for q, loop in targets:
+            def _deliver() -> None:
+                try:
+                    q.put_nowait(message)
+                except asyncio.QueueFull:
+                    # drop message for that slow consumer
+                    pass
+
+            loop.call_soon_threadsafe(_deliver)
 
 
 timeline_realtime_bus = TimelineRealtimeBus()

--- a/services/timeline_service.py
+++ b/services/timeline_service.py
@@ -37,20 +37,16 @@ class TimelineService:
         # Publish realtime update to connected websocket clients (case-scoped)
         # Fire-and-forget: timeline_realtime_bus is in-memory, so async scheduling
         # keeps DB write latency low.
-        payload = {
-            "type": "timeline_event",
-            "case_id": case_id,
-            "event_type": event.event_type,
-            "description": event.description,
-            "timestamp": event.event_date,
-            "metadata": event.event_metadata or {},
-            "event_id": event.id,
-        }
-        try:
-            validated_payload = TimelineEventPayload.model_validate(payload)
-            publish_timeline_event_best_effort(validated_payload.model_dump(mode="json"))
-        except Exception:
-            pass
+        payload = TimelineEventPayload(
+            type="timeline_event",
+            case_id=case_id,
+            event_type=event.event_type,
+            description=event.description,
+            timestamp=event.event_date,
+            metadata=event.event_metadata or {},
+            event_id=event.id,
+        )
+        publish_timeline_event_best_effort(payload.model_dump(mode="json"))
 
         return event
 

--- a/tests/test_case_api.py
+++ b/tests/test_case_api.py
@@ -114,6 +114,15 @@ def test_list_cases_success(client, test_db):
     
     assert payload["total"] == 2
     assert len(payload["cases"]) == 2
+    assert all(set(case_payload) == {
+        "case_id",
+        "case_number",
+        "title",
+        "parties",
+        "jurisdiction",
+        "status",
+        "summary",
+    } for case_payload in payload["cases"])
     
     # Check that cases belong to user 42 and details are correct
     case_ids = {c["case_id"] for c in payload["cases"]}
@@ -135,6 +144,15 @@ def test_get_case_details_success(client, test_db):
     response = client.get(f"/api/v1/cases/{case_one.id}")
     assert response.status_code == 200
     payload = response.json()
+    assert set(payload) == {
+        "case_id",
+        "case_number",
+        "title",
+        "parties",
+        "jurisdiction",
+        "status",
+        "summary",
+    }
     
     assert payload["case_id"] == str(case_one.id)
     assert payload["case_number"] == case_one.case_number

--- a/tests/test_case_api.py
+++ b/tests/test_case_api.py
@@ -2,7 +2,7 @@ import os
 os.environ["JWT_SECRET_KEY"] = "test-secret-key-value-12345"
 os.environ["APP_ALLOWED_HOSTS"] = "localhost"
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -84,14 +84,22 @@ def _seed_cases(test_db):
     test_db.refresh(case_two)
     test_db.refresh(case_three)
     
-    # Document for Case One to test summary
-    doc = CaseDocument(
+    # Documents for Case One to test latest-document selection
+    older_doc = CaseDocument(
         case_id=case_one.id,
         document_type=DocumentType.JUDGMENT,
         document_content="This is the plaint content.",
-        summary="Summary of Case One Plaint",
+        summary="Older summary",
+        uploaded_at=now - timedelta(days=2),
     )
-    test_db.add(doc)
+    newer_doc = CaseDocument(
+        case_id=case_one.id,
+        document_type=DocumentType.ORDER,
+        document_content="This is the later order content.",
+        summary="Latest summary",
+        uploaded_at=now - timedelta(days=1),
+    )
+    test_db.add_all([older_doc, newer_doc])
     test_db.commit()
     
     return case_one, case_two, case_three
@@ -133,7 +141,7 @@ def test_list_cases_success(client, test_db):
     # Verify latest document summary mapping works
     for c in payload["cases"]:
         if c["case_id"] == str(case_one.id):
-            assert c["summary"] == "Summary of Case One Plaint"
+            assert c["summary"] == "Latest summary"
         else:
             assert c["summary"] == ""
 
@@ -157,7 +165,7 @@ def test_get_case_details_success(client, test_db):
     assert payload["case_id"] == str(case_one.id)
     assert payload["case_number"] == case_one.case_number
     assert payload["title"] == case_one.title
-    assert payload["summary"] == "Summary of Case One Plaint"
+    assert payload["summary"] == "Latest summary"
     assert payload["status"] == "active"
 
 

--- a/tests/test_case_timeline_api.py
+++ b/tests/test_case_timeline_api.py
@@ -1,28 +1,141 @@
+import os
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+# api.auth -> api.config loads settings at import-time. Ensure required env vars exist first.
+os.environ["JWT_SECRET_KEY"] = "test-secret-key-value-12345"
+os.environ["APP_ALLOWED_HOSTS"] = "localhost"
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 import api.routes.cases as cases_route
 from api.auth import CurrentUser, get_current_user
+from database import Base, Case, CaseStatus, CaseTimeline
 
 
-def test_case_timeline_response_matches_model(monkeypatch):
+@pytest.fixture()
+def test_db():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(
+        autocommit=False,
+        autoflush=False,
+        expire_on_commit=False,
+        bind=engine,
+    )
+    db = SessionLocal()
+    yield db
+    db.close()
+
+
+@pytest.fixture()
+def client(test_db):
     app = FastAPI()
     app.include_router(cases_route.router)
     app.dependency_overrides[get_current_user] = lambda: CurrentUser("42", "tester@example.com", "user")
+    app.dependency_overrides[cases_route.get_db] = lambda: test_db
+    return TestClient(app)
 
-    monkeypatch.setattr(cases_route, "get_db", lambda: None)
 
-    client = TestClient(app)
-    response = client.get("/api/v1/cases/CASE-123/timeline")
+def _seed_case_with_timeline(test_db, user_id: int = 42):
+    created_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    case = Case(
+        user_id=user_id,
+        case_number="2023-CV-00001",
+        case_type="civil",
+        jurisdiction="Delhi",
+        status=CaseStatus.CLOSED,
+        title="Example Case",
+        created_at=created_at,
+        updated_at=created_at + timedelta(days=365),
+    )
+    test_db.add(case)
+    test_db.commit()
+    test_db.refresh(case)
+
+    test_db.add_all(
+        [
+            CaseTimeline(
+                case_id=case.id,
+                event_type="filing",
+                event_date=created_at,
+                description="Case filed",
+                event_metadata={
+                    "court": "District Court",
+                    "location": "New York, NY",
+                    "documents": ["complaint.pdf"],
+                },
+            ),
+            CaseTimeline(
+                case_id=case.id,
+                event_type="hearing",
+                event_date=created_at + timedelta(days=30),
+                description="Initial hearing",
+                event_metadata={
+                    "court": "District Court",
+                    "judge": "Judge Smith",
+                    "location": "New York, NY",
+                },
+            ),
+            CaseTimeline(
+                case_id=case.id,
+                event_type="decision",
+                event_date=created_at + timedelta(days=365),
+                description="Court decision rendered",
+                event_metadata={
+                    "court": "District Court",
+                    "judge": "Judge Smith",
+                    "location": "New York, NY",
+                    "documents": ["decision.pdf"],
+                },
+            ),
+        ]
+    )
+    test_db.commit()
+
+    return case
+
+
+def test_case_timeline_response_matches_model(client, test_db):
+    case = _seed_case_with_timeline(test_db)
+
+    response = client.get(f"/api/v1/cases/{case.id}/timeline")
 
     assert response.status_code == 200
     payload = response.json()
 
-    assert payload["case_id"] == "CASE-123"
-    assert payload["case_number"] == "2023-CV-00001"
+    assert payload["case_id"] == str(case.id)
+    assert payload["case_number"] == case.case_number
     assert payload["title"] == "Example Case"
     assert payload["status"] == "closed"
-    assert payload["total_events"] == 5
+    assert payload["total_events"] == 3
     assert payload["duration_years"] == 1.0
-    assert len(payload["events"]) == 5
-    assert all("date" in event and "event_type" in event and "description" in event for event in payload["events"])
+    assert len(payload["events"]) == 3
+
+    filing = next(event for event in payload["events"] if event["event_type"] == "filing")
+    hearing = next(event for event in payload["events"] if event["event_type"] == "hearing")
+    decision = next(event for event in payload["events"] if event["event_type"] == "decision")
+
+    assert filing["court"] == "District Court"
+    assert filing["location"] == "New York, NY"
+    assert filing["documents"] == ["complaint.pdf"]
+    assert hearing["judge"] == "Judge Smith"
+    assert decision["documents"] == ["decision.pdf"]
+
+
+def test_case_timeline_forbidden_for_other_user(client, test_db):
+    case = _seed_case_with_timeline(test_db, user_id=99)
+
+    response = client.get(f"/api/v1/cases/{case.id}/timeline")
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Forbidden: You do not own this case"

--- a/tests/test_case_timeline_websocket.py
+++ b/tests/test_case_timeline_websocket.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime, timezone
 
 import pytest
 from fastapi.testclient import TestClient
@@ -68,24 +69,33 @@ def test_case_timeline_ws_subscribed_and_forwards_event(mock_verify_token, clien
 
         # Publish directly into the realtime bus. This avoids DB/session coupling in the websocket test.
         from services.timeline_realtime import timeline_realtime_bus
-        timeline_payload = {
-            "type": "timeline_event",
-            "case_id": case_id,
-            "event_type": "deadline_created",
-            "description": "Manual deadline added",
-            "timestamp": "2023-01-01T00:00:00+00:00",
-            "metadata": {"deadline_id": 999},
-            "event_id": 555,
-        }
+        timeline_payload = TimelineEventPayload(
+            type="timeline_event",
+            case_id=case_id,
+            event_type="deadline_created",
+            description="Manual deadline added",
+            timestamp=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            metadata={"deadline_id": 999},
+            event_id=555,
+        )
 
         # timeline_realtime_bus.publish() is async; TestClient is sync,
         # so we run a short event-loop to publish.
         import asyncio
 
-        asyncio.run(timeline_realtime_bus.publish(case_id=case_id, payload=timeline_payload))
+        asyncio.run(timeline_realtime_bus.publish(case_id=case_id, payload=timeline_payload.model_dump(mode="json")))
 
         msg = websocket.receive_json()
         validated = TimelineEventPayload.model_validate(msg)
+        assert set(validated.model_dump(mode="json")) == {
+            "type",
+            "case_id",
+            "event_type",
+            "description",
+            "timestamp",
+            "metadata",
+            "event_id",
+        }
         assert validated.type == "timeline_event"
         assert validated.case_id == case_id
         assert validated.event_type == "deadline_created"

--- a/tests/test_timeline_realtime.py
+++ b/tests/test_timeline_realtime.py
@@ -1,5 +1,6 @@
 import asyncio
 from datetime import datetime, timezone
+from unittest.mock import patch
 
 import pytest
 
@@ -119,5 +120,53 @@ def test_publish_rejects_invalid_payload_shape():
                     "metadata": {},
                 },
             )
+
+    asyncio.run(scenario())
+
+
+def test_publish_keeps_latest_message_when_queue_is_full():
+    bus = TimelineRealtimeBus(queue_maxsize=1)
+
+    async def scenario() -> None:
+        queue = await bus.subscribe(7)
+        assert queue.maxsize == 1
+        assert bus.queue_maxsize == 1
+
+        with patch("services.timeline_realtime.logger.warning") as mock_warning:
+            await bus.publish(
+                7,
+                {
+                    "type": "timeline_event",
+                    "case_id": 7,
+                    "event_type": "deadline_created",
+                    "description": "Oldest message",
+                    "timestamp": datetime(2026, 5, 22, 10, 30, tzinfo=timezone.utc),
+                    "metadata": {},
+                    "event_id": 1,
+                },
+            )
+            await bus.publish(
+                7,
+                {
+                    "type": "timeline_event",
+                    "case_id": 7,
+                    "event_type": "deadline_created",
+                    "description": "Newest message",
+                    "timestamp": datetime(2026, 5, 22, 10, 31, tzinfo=timezone.utc),
+                    "metadata": {},
+                    "event_id": 2,
+                },
+            )
+
+            payload = await queue.get()
+            validated = TimelineEventPayload.model_validate(payload)
+
+            assert validated.description == "Newest message"
+            assert validated.event_id == 2
+            assert bus.dropped_messages_total == 1
+            assert bus._channels[7].dropped_messages == 1
+            assert mock_warning.call_count == 1
+            assert mock_warning.call_args.kwargs["policy"] == "drop_oldest_keep_latest"
+            assert mock_warning.call_args.kwargs["case_id"] == 7
 
     asyncio.run(scenario())

--- a/tests/test_timeline_realtime.py
+++ b/tests/test_timeline_realtime.py
@@ -58,6 +58,24 @@ def test_publish_normalizes_datetimes_to_utc_iso():
 
         payload = await queue.get()
         validated = TimelineEventPayload.model_validate(payload)
+        assert set(TimelineEventPayload.model_fields) == {
+            "type",
+            "case_id",
+            "event_type",
+            "description",
+            "timestamp",
+            "metadata",
+            "event_id",
+        }
+        assert set(validated.model_dump(mode="json")) == {
+            "type",
+            "case_id",
+            "event_type",
+            "description",
+            "timestamp",
+            "metadata",
+            "event_id",
+        }
         assert validated.type == "timeline_event"
         assert validated.case_id == 7
         assert validated.event_type == "deadline_created"
@@ -67,6 +85,22 @@ def test_publish_normalizes_datetimes_to_utc_iso():
         assert validated.model_dump(mode="json")["metadata"]["nested_timestamp"] == "2026-05-22T10:31:00+00:00"
 
     asyncio.run(scenario())
+
+
+def test_timeline_event_payload_rejects_extra_fields():
+    with pytest.raises(ValidationError):
+        TimelineEventPayload.model_validate(
+            {
+                "type": "timeline_event",
+                "case_id": 7,
+                "event_type": "deadline_created",
+                "description": "Manual deadline added",
+                "timestamp": datetime(2026, 5, 22, 10, 30, tzinfo=timezone.utc),
+                "metadata": {},
+                "event_id": 555,
+                "unexpected": "value",
+            }
+        )
 
 
 def test_publish_rejects_invalid_payload_shape():


### PR DESCRIPTION
Implemented keep-latest backpressure in timeline_realtime.py: each subscriber queue now has a configurable max size via `TIMELINE_REALTIME_QUEUE_MAXSIZE` (default `100`), and when a queue is full the oldest item is evicted so the newest event is preserved. Drops are counted and emitted through structured warnings with fields like `case_id`, `policy`, and cumulative drop totals.

I also added coverage in test_timeline_realtime.py for the overflow path, confirming the newest payload wins, the drop counter increments, and the warning is emitted. Validation passed: `pytest test_timeline_realtime.py -q`.


closes #885