### PR TITLE
[Security] Missing/unclear authz checks on API routes

### DIFF
--- a/api/routes/case_search.py
+++ b/api/routes/case_search.py
@@ -3,13 +3,13 @@ API routes for Case Search and Precedent Matching
 Endpoints for finding similar cases, precedents, comparisons, and knowledge graph queries.
 """
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 from typing import List, Optional
 
 from database import get_db
 from api.auth import get_current_user
-from database import User
+from database import User, Case
 
 # Import case search engines
 from core.embedding_engine import EmbeddingEngine
@@ -26,6 +26,17 @@ router = APIRouter(prefix="/api/cases", tags=["case-search"])
 
 # Initialize engines
 embedding_engine = EmbeddingEngine()
+
+
+def _require_owned_case(case_id: int, current_user: User, db: Session) -> Case:
+    case = db.query(Case).filter(Case.id == case_id).first()
+    if not case:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Case not found")
+
+    if current_user.role != "admin" and case.user_id != current_user.user_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Case not found")
+
+    return case
 
 
 # ==================== Case Search Endpoints ====================
@@ -59,6 +70,8 @@ def search_similar_cases(
     Returns:
         List of similar cases with similarity scores
     """
+    _require_owned_case(case_id, current_user, db)
+
     try:
         search_engine = SemanticCaseSearch(embedding_engine)
         results = search_engine.search_similar_cases(
@@ -168,6 +181,8 @@ def get_winning_precedents(
     Returns:
         List of precedent cases with winning arguments
     """
+    _require_owned_case(case_id, current_user, db)
+
     try:
         results = PrecedentMatcher.find_winning_precedents(
             db=db,
@@ -207,6 +222,8 @@ def get_losing_precedents(
     Returns:
         List of cases to avoid based on failed arguments
     """
+    _require_owned_case(case_id, current_user, db)
+
     try:
         results = PrecedentMatcher.find_losing_precedents(
             db=db,
@@ -307,6 +324,8 @@ def compare_cases(
     Returns:
         Detailed comparison including issues, arguments, and differences
     """
+    _require_owned_case(case_id, current_user, db)
+
     try:
         comparison = CaseComparison.compare_cases(db, case_id, precedent_id)
         return comparison
@@ -332,6 +351,8 @@ def get_comparison_suggestions(
     Returns:
         List of suggested arguments based on winning precedents
     """
+    _require_owned_case(case_id, current_user, db)
+
     try:
         suggestions = CaseComparison.suggest_arguments(db, case_id, precedent_id)
         return {
@@ -362,6 +383,8 @@ def get_comparison_differences(
     Returns:
         Highlighted differences and warnings
     """
+    _require_owned_case(case_id, current_user, db)
+
     try:
         differences = CaseComparison.highlight_differences(db, case_id, precedent_id)
         return differences
@@ -446,6 +469,8 @@ def index_case(
     Returns:
         Indexing status
     """
+    _require_owned_case(case_id, current_user, db)
+
     try:
         embedding_obj = embedding_engine.embed_case(
             db=db,
@@ -484,6 +509,8 @@ def extract_case_issues(
     Returns:
         List of extracted issues
     """
+    _require_owned_case(case_id, current_user, db)
+
     try:
         issues = KnowledgeGraphBuilder.extract_issues_from_case(
             db=db,
@@ -522,6 +549,8 @@ def extract_case_arguments(
     Returns:
         List of extracted arguments
     """
+    _require_owned_case(case_id, current_user, db)
+
     try:
         arguments = KnowledgeGraphBuilder.extract_arguments_from_case(
             db=db,

--- a/api/routes/cases.py
+++ b/api/routes/cases.py
@@ -69,7 +69,7 @@ def get_owned_case(case_id: str, current_user: CurrentUser, db: Session) -> Case
     if not case:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Case not found")
 
-    if case.user_id != user_id_int:
+    if current_user.role != "admin" and case.user_id != user_id_int:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden: You do not own this case")
 
     return case

--- a/api/routes/deadlines.py
+++ b/api/routes/deadlines.py
@@ -5,13 +5,61 @@ GET /api/v1/deadlines/{deadline_id} - Get deadline details
 POST /api/v1/deadlines - Create new deadline
 """
 from fastapi import APIRouter, HTTPException, status, Depends
+from sqlalchemy.orm import Session
 from api.models import DeadlineResponse, UpcomingDeadlinesResponse
 from api.auth import get_current_user, CurrentUser
 import structlog
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+
+from database import Case, CaseDeadline, get_db
 
 router = APIRouter(prefix="/api/v1/deadlines", tags=["deadlines"])
 logger = structlog.get_logger(__name__)
+
+
+def _deadline_priority(days_until_due: int) -> str:
+    if days_until_due <= 3:
+        return "critical"
+    if days_until_due <= 10:
+        return "high"
+    if days_until_due <= 30:
+        return "medium"
+    return "low"
+
+
+def _require_owned_case(case_id: str | None, current_user: CurrentUser, db: Session) -> Case | None:
+    if case_id is None:
+        return None
+
+    try:
+        case_id_int = int(case_id)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid case ID format")
+
+    case = db.query(Case).filter(Case.id == case_id_int).first()
+    if not case:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Case not found")
+
+    if current_user.role != "admin" and case.user_id != current_user.user_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Case not found")
+
+    return case
+
+
+def _require_owned_deadline(deadline_id: str, current_user: CurrentUser, db: Session) -> CaseDeadline:
+    try:
+        deadline_id_int = int(deadline_id)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid deadline ID format")
+
+    deadline = db.query(CaseDeadline).filter(CaseDeadline.id == deadline_id_int).first()
+    if not deadline:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Deadline not found")
+
+    if current_user.role != "admin" and deadline.user_id != current_user.user_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Deadline not found")
+
+    return deadline
 
 
 @router.get(
@@ -108,7 +156,8 @@ async def get_upcoming_deadlines(
 )
 async def get_deadline_details(
     deadline_id: str,
-    current_user: CurrentUser = Depends(get_current_user)
+    current_user: CurrentUser = Depends(get_current_user),
+    db: Session = Depends(get_db),
 ) -> DeadlineResponse:
     """Get complete deadline details"""
     
@@ -118,20 +167,25 @@ async def get_deadline_details(
         user_id=current_user.user_id
     )
     
+    deadline = _require_owned_deadline(deadline_id, current_user, db)
     now = datetime.now(timezone.utc)
+    due_date = deadline.deadline_date
+    if due_date is not None and due_date.tzinfo is None:
+        due_date = due_date.replace(tzinfo=timezone.utc)
+    days_until = deadline.days_until_deadline()
     return DeadlineResponse(
-        deadline_id=deadline_id,
+        deadline_id=str(deadline.id),
         user_id=current_user.user_id,
-        case_id="case_001",
-        title="Example Deadline",
-        description="Example deadline description",
-        due_date=now + timedelta(days=5),
-        days_until_due=5,
-        priority="high",
-        status="pending",
+        case_id=str(deadline.case_id),
+        title=deadline.case_title,
+        description=deadline.description or "",
+        due_date=due_date or now,
+        days_until_due=days_until,
+        priority=_deadline_priority(days_until),
+        status="completed" if deadline.is_completed else ("overdue" if due_date and due_date < now else "pending"),
         reminder_enabled=True,
         reminder_days=7,
-        created_at=now
+        created_at=deadline.created_at
     )
 
 
@@ -147,7 +201,8 @@ async def create_deadline(
     priority: str = "medium",
     case_id: str = None,
     reminder_days: int = 7,
-    current_user: CurrentUser = Depends(get_current_user)
+    current_user: CurrentUser = Depends(get_current_user),
+    db: Session = Depends(get_db)
 ) -> DeadlineResponse:
     """Create a new deadline"""
     
@@ -157,6 +212,8 @@ async def create_deadline(
         title=title
     )
     
+    _require_owned_case(case_id, current_user, db)
+
     now = datetime.now(timezone.utc)
     days_until = (due_date - now).days
     
@@ -168,7 +225,7 @@ async def create_deadline(
         description=description,
         due_date=due_date,
         days_until_due=days_until,
-        priority=priority,
+        priority=priority or _deadline_priority(days_until),
         status="pending",
         reminder_enabled=True,
         reminder_days=reminder_days,
@@ -186,7 +243,8 @@ async def update_deadline(
     title: str = None,
     due_date: datetime = None,
     priority: str = None,
-    current_user: CurrentUser = Depends(get_current_user)
+    current_user: CurrentUser = Depends(get_current_user),
+    db: Session = Depends(get_db)
 ) -> DeadlineResponse:
     """Update a deadline"""
     
@@ -196,19 +254,23 @@ async def update_deadline(
         user_id=current_user.user_id
     )
     
-    # In production, fetch and update from database
+    deadline = _require_owned_deadline(deadline_id, current_user, db)
     now = datetime.now(timezone.utc)
+    effective_due_date = due_date or deadline.deadline_date
+    if effective_due_date is not None and effective_due_date.tzinfo is None:
+        effective_due_date = effective_due_date.replace(tzinfo=timezone.utc)
+    days_until = ((effective_due_date or now) - now).days
     return DeadlineResponse(
-        deadline_id=deadline_id,
+        deadline_id=str(deadline.id),
         user_id=current_user.user_id,
-        case_id="case_001",
-        title=title or "Updated Deadline",
-        description="Updated description",
-        due_date=due_date or (now + timedelta(days=7)),
-        days_until_due=7,
-        priority=priority or "medium",
-        status="pending",
+        case_id=str(deadline.case_id),
+        title=title or deadline.case_title,
+        description=deadline.description or "",
+        due_date=effective_due_date or now,
+        days_until_due=days_until,
+        priority=priority or _deadline_priority(days_until),
+        status="completed" if deadline.is_completed else ("overdue" if effective_due_date and effective_due_date < now else "pending"),
         reminder_enabled=True,
         reminder_days=7,
-        created_at=now
+        created_at=deadline.created_at
     )

--- a/tests/test_case_search_authz.py
+++ b/tests/test_case_search_authz.py
@@ -1,0 +1,73 @@
+import os
+
+os.environ["JWT_SECRET_KEY"] = "test-secret-key-value-12345"
+os.environ["APP_ALLOWED_HOSTS"] = "localhost"
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import api.routes.case_search as case_search_route
+from api.auth import CurrentUser, get_current_user
+from database import Base, Case, CaseStatus
+
+
+@pytest.fixture()
+def test_db():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(
+        autocommit=False,
+        autoflush=False,
+        expire_on_commit=False,
+        bind=engine,
+    )
+    db = SessionLocal()
+    yield db
+    db.close()
+
+
+@pytest.fixture()
+def client(test_db):
+    app = FastAPI()
+    app.include_router(case_search_route.router)
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser("42", "tester@example.com", "user")
+    app.dependency_overrides[case_search_route.get_db] = lambda: test_db
+    return TestClient(app)
+
+
+def _seed_case(test_db, *, user_id: int):
+    case = Case(
+        user_id=user_id,
+        case_number=f"CASE-{user_id}",
+        case_type="civil",
+        jurisdiction="Delhi",
+        status=CaseStatus.ACTIVE,
+        title="Example Case",
+    )
+    test_db.add(case)
+    test_db.commit()
+    test_db.refresh(case)
+    return case
+
+
+def test_search_similar_rejects_other_users_case(client, test_db, monkeypatch):
+    case = _seed_case(test_db, user_id=99)
+
+    monkeypatch.setattr(
+        case_search_route.SemanticCaseSearch,
+        "search_similar_cases",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("search should not run for unauthorized case")),
+    )
+
+    response = client.get(f"/api/cases/{case.id}/search-similar")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Case not found"

--- a/tests/test_deadlines_api.py
+++ b/tests/test_deadlines_api.py
@@ -1,0 +1,110 @@
+import os
+from datetime import datetime, timedelta, timezone
+
+os.environ["JWT_SECRET_KEY"] = "test-secret-key-value-12345"
+os.environ["APP_ALLOWED_HOSTS"] = "localhost"
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import api.routes.deadlines as deadlines_route
+from api.auth import CurrentUser, get_current_user
+from database import Base, Case, CaseDeadline, CaseStatus
+
+
+@pytest.fixture()
+def test_db():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(
+        autocommit=False,
+        autoflush=False,
+        expire_on_commit=False,
+        bind=engine,
+    )
+    db = SessionLocal()
+    yield db
+    db.close()
+
+
+@pytest.fixture()
+def client(test_db):
+    app = FastAPI()
+    app.include_router(deadlines_route.router)
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser("42", "tester@example.com", "user")
+    app.dependency_overrides[deadlines_route.get_db] = lambda: test_db
+    return TestClient(app)
+
+
+def _seed_case_and_deadline(test_db, *, user_id: int = 42):
+    case = Case(
+        user_id=user_id,
+        case_number=f"CASE-{user_id}",
+        case_type="civil",
+        jurisdiction="Delhi",
+        status=CaseStatus.ACTIVE,
+        title="Example Case",
+    )
+    test_db.add(case)
+    test_db.commit()
+    test_db.refresh(case)
+
+    deadline = CaseDeadline(
+        user_id=user_id,
+        case_id=case.id,
+        case_title=case.title,
+        deadline_date=datetime.now(timezone.utc) + timedelta(days=10),
+        deadline_type="appeal",
+        description="Appeal deadline",
+        is_completed=False,
+    )
+    test_db.add(deadline)
+    test_db.commit()
+    test_db.refresh(deadline)
+    return case, deadline
+
+
+def test_get_deadline_details_forbidden_for_other_user(client, test_db):
+    _, deadline = _seed_case_and_deadline(test_db, user_id=99)
+
+    response = client.get(f"/api/v1/deadlines/{deadline.id}")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Deadline not found"
+
+
+def test_create_deadline_forbidden_for_other_users_case(client, test_db):
+    case, _ = _seed_case_and_deadline(test_db, user_id=99)
+    due_date = (datetime.now(timezone.utc) + timedelta(days=5)).isoformat()
+
+    response = client.post(
+        "/api/v1/deadlines",
+        params={
+            "title": "Cross-user deadline",
+            "due_date": due_date,
+            "case_id": str(case.id),
+        },
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Case not found"
+
+
+def test_update_deadline_forbidden_for_other_user(client, test_db):
+    _, deadline = _seed_case_and_deadline(test_db, user_id=99)
+
+    response = client.put(
+        f"/api/v1/deadlines/{deadline.id}",
+        params={"title": "Updated title"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Deadline not found"


### PR DESCRIPTION
Implemented the authz hardening in the route layers that actually accept guessed IDs. Case-search now does a shared ownership check before any similarity/comparison/indexing work, deadline lookups and updates now load the row first and reject non-owners, and the case helper now allows admin bypass where appropriate. The deadline route also had a broken `timezone` import/use path, which is now fixed. Relevant anchors are case_search.py, deadlines.py, and cases.py.

I added cross-user regression tests for deadline GET/POST/PUT and a representative case-search ID route in test_deadlines_api.py and test_case_search_authz.py. I did not find an HTTP notification route in the current routes package, so there was nothing concrete to patch there.

closes #959