### PR TITLE
Notification delivery webhooks + accurate delivered/failed tracking

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -58,7 +58,7 @@ from api.validation import (
 )
 
 # Import routes
-from api.routes import documents, cases, reports, analytics, deadlines, auth, health, case_search, speech, document_verification, argument_strength, deadline_engine, efiling
+from api.routes import documents, cases, reports, analytics, deadlines, auth, health, case_search, speech, document_verification, argument_strength, deadline_engine, efiling, notifications as notifications_webhooks
 
 settings = get_settings()
 logger = structlog.get_logger(__name__)
@@ -88,7 +88,7 @@ middleware = [
     Middleware(
         CSRFProtectionMiddleware,
         allowed_hosts=set(settings.ALLOWED_HOSTS),
-        exempt_paths={"/health", "/ready", "/metrics", "/docs", "/openapi.json"}
+        exempt_paths={"/health", "/ready", "/metrics", "/docs", "/openapi.json", "/api/v1/webhooks/twilio", "/api/v1/webhooks/sendgrid"}
     ),
 ]
 
@@ -180,6 +180,7 @@ def create_app() -> FastAPI:
     app.include_router(argument_strength.router)
     app.include_router(deadline_engine.router)
     app.include_router(efiling.router)
+    app.include_router(notifications_webhooks.router)
     # Model feedback & optimization
     from api.routes import models as models_router
     app.include_router(models_router.router)

--- a/api/middlewares/idempotency.py
+++ b/api/middlewares/idempotency.py
@@ -110,7 +110,11 @@ def _request_principal(request: Request) -> str:
 
 
 def _idempotency_exempt_path(path: str) -> bool:
-    return path in SKIP_PATHS or path in {"/openapi.json", "/docs", "/redoc"}
+    return (
+        path in SKIP_PATHS
+        or path in {"/openapi.json", "/docs", "/redoc"}
+        or path.startswith("/api/v1/webhooks/")
+    )
 
 
 def _response_headers_for_cache(response: Response) -> dict:

--- a/api/routes/notifications.py
+++ b/api/routes/notifications.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import json
+from urllib.parse import parse_qsl
+
+import structlog
+from fastapi import APIRouter, Depends, Request, status
+from sqlalchemy.orm import Session
+
+from api.errors import StructuredAPIError
+from config import Config
+from database import get_db
+from db.crud.notifications import update_notification_log_by_message_id
+from db.models.notifications import NotificationStatus
+
+try:
+    from twilio.request_validator import RequestValidator
+except ImportError:  # pragma: no cover - optional dependency
+    RequestValidator = None
+
+try:
+    from sendgrid.helpers.eventwebhook import EventWebhook, EventWebhookHeader
+except ImportError:  # pragma: no cover - optional dependency
+    EventWebhook = None
+    EventWebhookHeader = None
+
+router = APIRouter(prefix="/api/v1/webhooks", tags=["notifications"])
+logger = structlog.get_logger(__name__)
+
+
+def _message_id_candidates(message_id: str | None) -> list[str]:
+    if not message_id:
+        return []
+
+    candidates: list[str] = []
+    normalized = message_id.strip().strip("<>")
+    if normalized:
+        candidates.append(normalized)
+        if "." in normalized:
+            candidates.append(normalized.split(".", 1)[0])
+        if "@" in normalized:
+            candidates.append(normalized.split("@", 1)[0])
+
+    return list(dict.fromkeys(candidates))
+
+
+def _verify_twilio_signature(request: Request, params: dict[str, str]) -> bool:
+    signature = request.headers.get("X-Twilio-Signature") or request.headers.get("x-twilio-signature")
+    if not signature:
+        raise StructuredAPIError(status_code=status.HTTP_401_UNAUTHORIZED, error_code="TWILIO_SIGNATURE_MISSING", message="Missing Twilio signature header")
+
+    if not Config.get_twilio_auth_token():
+        raise StructuredAPIError(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, error_code="TWILIO_WEBHOOK_NOT_CONFIGURED", message="Twilio auth token is not configured")
+
+    if RequestValidator is None:
+        raise StructuredAPIError(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, error_code="TWILIO_WEBHOOK_VALIDATION_UNAVAILABLE", message="Twilio request validator is not installed")
+
+    validator = RequestValidator(Config.get_twilio_auth_token())
+    return bool(validator.validate(str(request.url), params, signature))
+
+
+def _verify_sendgrid_signature(request: Request, payload: str) -> bool:
+    signature_header = EventWebhookHeader.SIGNATURE if EventWebhookHeader else "X-Twilio-Email-Event-Webhook-Signature"
+    timestamp_header = EventWebhookHeader.TIMESTAMP if EventWebhookHeader else "X-Twilio-Email-Event-Webhook-Timestamp"
+
+    signature = request.headers.get(signature_header)
+    timestamp = request.headers.get(timestamp_header)
+    if not signature or not timestamp:
+        raise StructuredAPIError(status_code=status.HTTP_401_UNAUTHORIZED, error_code="SENDGRID_SIGNATURE_MISSING", message="Missing SendGrid signature headers")
+
+    public_key = Config.get_sendgrid_event_webhook_public_key()
+    if not public_key:
+        raise StructuredAPIError(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, error_code="SENDGRID_WEBHOOK_NOT_CONFIGURED", message="SendGrid event webhook public key is not configured")
+
+    if EventWebhook is None:
+        raise StructuredAPIError(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, error_code="SENDGRID_WEBHOOK_VALIDATION_UNAVAILABLE", message="SendGrid event webhook validator is not installed")
+
+    verifier = EventWebhook(public_key)
+    return bool(verifier.verify_signature(payload, signature, timestamp))
+
+
+def _update_delivery_status(db: Session, message_id: str | None, status_value: NotificationStatus, error_message: str | None = None, message_preview: str | None = None):
+    for candidate in _message_id_candidates(message_id):
+        updated = update_notification_log_by_message_id(
+            db=db,
+            message_id=candidate,
+            status=status_value,
+            error_message=error_message,
+            message_preview=message_preview,
+        )
+        if updated:
+            return updated
+    return None
+
+
+@router.post("/twilio")
+async def twilio_delivery_webhook(request: Request, db: Session = Depends(get_db)) -> dict:
+    raw_body = (await request.body()).decode("utf-8")
+    params = dict(parse_qsl(raw_body, keep_blank_values=True))
+
+    if not _verify_twilio_signature(request, params):
+        raise StructuredAPIError(status_code=status.HTTP_401_UNAUTHORIZED, error_code="TWILIO_SIGNATURE_INVALID", message="Invalid Twilio signature")
+
+    message_sid = params.get("MessageSid") or params.get("SmsSid") or params.get("SmsMessageSid")
+    message_status = (params.get("MessageStatus") or params.get("SmsStatus") or "").lower()
+    error_code = params.get("ErrorCode")
+
+    if message_status == "delivered":
+        updated = _update_delivery_status(db, message_sid, NotificationStatus.DELIVERED)
+    elif message_status in {"failed", "undelivered", "canceled", "cancelled"}:
+        updated = _update_delivery_status(db, message_sid, NotificationStatus.FAILED, error_message=f"Twilio status: {message_status}{f' ({error_code})' if error_code else ''}")
+    else:
+        updated = None
+
+    logger.info("twilio_delivery_webhook_processed", message_id=message_sid, status=message_status, updated=bool(updated))
+    return {"ok": True, "updated": bool(updated), "status": message_status}
+
+
+@router.post("/sendgrid")
+async def sendgrid_delivery_webhook(request: Request, db: Session = Depends(get_db)) -> dict:
+    raw_body = (await request.body()).decode("utf-8")
+
+    if not _verify_sendgrid_signature(request, raw_body):
+        raise StructuredAPIError(status_code=status.HTTP_401_UNAUTHORIZED, error_code="SENDGRID_SIGNATURE_INVALID", message="Invalid SendGrid signature")
+
+    try:
+        events = json.loads(raw_body or "[]")
+    except json.JSONDecodeError as exc:
+        raise StructuredAPIError(status_code=status.HTTP_400_BAD_REQUEST, error_code="SENDGRID_WEBHOOK_INVALID_JSON", message="Invalid SendGrid webhook payload") from exc
+
+    if isinstance(events, dict):
+        events = [events]
+
+    processed = 0
+    updated = 0
+    for event in events:
+        processed += 1
+        event_type = str(event.get("event", "")).lower()
+        message_id = event.get("sg_message_id") or event.get("message_id") or event.get("smtp-id")
+        if event_type == "delivered":
+            result = _update_delivery_status(db, message_id, NotificationStatus.DELIVERED)
+        elif event_type in {"bounce", "dropped", "deferred", "blocked", "spamreport", "invalid"}:
+            reason = event.get("reason") or event.get("response") or event_type
+            result = _update_delivery_status(db, message_id, NotificationStatus.FAILED, error_message=str(reason))
+        else:
+            result = None
+
+        updated += int(bool(result))
+
+    logger.info("sendgrid_delivery_webhook_processed", events=processed, updated=updated)
+    return {"ok": True, "events": processed, "updated": updated}

--- a/config.py
+++ b/config.py
@@ -181,6 +181,11 @@ class Config:
     SENDGRID_FROM_EMAIL = _get_val("SENDGRID_FROM_EMAIL", "noreply@legalassist.ai")
 
     @classmethod
+    def get_sendgrid_event_webhook_public_key(cls) -> str:
+        """Return the SendGrid event webhook public key, if configured."""
+        return str(_get_val("SENDGRID_EVENT_WEBHOOK_PUBLIC_KEY", _get_val("SENDGRID_WEBHOOK_PUBLIC_KEY", "")) or "")
+
+    @classmethod
     def get_sendgrid_api_key(cls) -> str:
         """Return the SendGrid API key, retrieved on demand to limit exposure."""
         return str(_get_val("SENDGRID_API_KEY", "") or "")

--- a/database.py
+++ b/database.py
@@ -197,6 +197,7 @@ class NotificationStatus(str, enum.Enum):
     """Status of sent notifications"""
     PENDING = "pending"
     SENT = "sent"
+    DELIVERED = "delivered"
     FAILED = "failed"
     BOUNCED = "bounced"
     OPENED = "opened"
@@ -294,6 +295,7 @@ class NotificationLog(Base):
     message_preview = Column(Text, nullable=True)
     sent_at = Column(DateTime(timezone=True), nullable=True)
     delivered_at = Column(DateTime(timezone=True), nullable=True)
+    failed_at = Column(DateTime(timezone=True), nullable=True)
     created_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), nullable=False)
 
     # Relationships

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -20,6 +20,7 @@ from .crud.notifications import (
     get_prefs_by_user_ids,
     has_notification_been_sent,
     log_notification,
+    update_notification_log_by_message_id,
     get_notification_history,
 )
 from .crud.knowledge import (
@@ -54,6 +55,7 @@ __all__ = [
     "get_prefs_by_user_ids",
     "has_notification_been_sent",
     "log_notification",
+    "update_notification_log_by_message_id",
     "get_notification_history",
     "submit_user_feedback",
     "get_user_feedback",

--- a/db/crud/notifications.py
+++ b/db/crud/notifications.py
@@ -69,8 +69,45 @@ def update_notification_log_by_keys(
         log.error_message = error_message
     if message_preview is not None:
         log.message_preview = message_preview
-    if status != NotificationStatus.PENDING:
-        log.sent_at = dt.datetime.now(dt.timezone.utc)
+    now = dt.datetime.now(dt.timezone.utc)
+    if status == NotificationStatus.SENT:
+        log.sent_at = now
+    elif status == NotificationStatus.DELIVERED:
+        log.delivered_at = now
+    elif status == NotificationStatus.FAILED:
+        log.failed_at = now
+    elif status != NotificationStatus.PENDING:
+        log.sent_at = now
+    db.commit()
+    db.refresh(log)
+    return log
+
+
+def update_notification_log_by_message_id(
+    db: Session,
+    message_id: str,
+    status: NotificationStatus,
+    error_message: Optional[str] = None,
+    message_preview: Optional[str] = None,
+) -> Optional[NotificationLog]:
+    log = db.query(NotificationLog).filter(NotificationLog.message_id == message_id).first()
+    if not log:
+        return None
+
+    log.status = status
+    if error_message is not None:
+        log.error_message = error_message
+    if message_preview is not None:
+        log.message_preview = message_preview
+
+    now = dt.datetime.now(dt.timezone.utc)
+    if status == NotificationStatus.DELIVERED:
+        log.delivered_at = now
+    elif status == NotificationStatus.FAILED:
+        log.failed_at = now
+    elif status == NotificationStatus.SENT:
+        log.sent_at = now
+
     db.commit()
     db.refresh(log)
     return log
@@ -143,7 +180,11 @@ def has_notification_been_sent(
         NotificationLog.deadline_id == deadline_id,
         NotificationLog.days_before == days_before,
         NotificationLog.channel == channel,
-        NotificationLog.status.in_([NotificationStatus.SENT, NotificationStatus.OPENED]),
+        NotificationLog.status.in_([
+            NotificationStatus.SENT,
+            NotificationStatus.DELIVERED,
+            NotificationStatus.OPENED,
+        ]),
     ).first() is not None
 
 
@@ -169,7 +210,9 @@ def log_notification(
         message_id=message_id,
         error_message=error_message,
         message_preview=message_preview,
-        sent_at=dt.datetime.now(dt.timezone.utc) if status != NotificationStatus.PENDING else None,
+        sent_at=dt.datetime.now(dt.timezone.utc) if status == NotificationStatus.SENT else None,
+        delivered_at=dt.datetime.now(dt.timezone.utc) if status == NotificationStatus.DELIVERED else None,
+        failed_at=dt.datetime.now(dt.timezone.utc) if status == NotificationStatus.FAILED else None,
     )
     db.add(log)
     db.flush()

--- a/db/models/notifications.py
+++ b/db/models/notifications.py
@@ -8,6 +8,7 @@ from db.base import Base
 class NotificationStatus(str, enum.Enum):
     PENDING = "pending"
     SENT = "sent"
+    DELIVERED = "delivered"
     FAILED = "failed"
     BOUNCED = "bounced"
     OPENED = "opened"
@@ -72,6 +73,7 @@ class NotificationLog(Base):
     message_preview = Column(Text, nullable=True)
     sent_at = Column(DateTime(timezone=True), nullable=True)
     delivered_at = Column(DateTime(timezone=True), nullable=True)
+    failed_at = Column(DateTime(timezone=True), nullable=True)
     created_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), nullable=False)
 
     deadline = relationship("CaseDeadline", back_populates="notifications")

--- a/tests/test_notification_webhooks.py
+++ b/tests/test_notification_webhooks.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from twilio.request_validator import RequestValidator
+
+import api.main as api_main
+from config import Config
+from database import get_db
+from db.base import Base
+from db.models.auth import User
+from db.models.cases import Case, CaseDeadline, CaseStatus
+from db.models.notifications import NotificationChannel, NotificationLog, NotificationStatus
+
+
+SENDGRID_PUBLIC_KEY = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE83T4O/n84iotIvIW4mdBgQ/7dAfSmpqIM8kF9mN1flpVKS3GRqe62gw+2fNNRaINXvVpiglSI8eNEc6wEA3F+g=="
+SENDGRID_SIGNATURE = "MEUCIGHQVtGj+Y3LkG9fLcxf3qfI10QysgDWmMOVmxG0u6ZUAiEAyBiXDWzM+uOe5W0JuG+luQAbPIqHh89M15TluLtEZtM="
+SENDGRID_TIMESTAMP = "1600112502"
+SENDGRID_PAYLOAD = (
+    json.dumps(
+        [
+            {
+                "email": "hello@world.com",
+                "event": "dropped",
+                "reason": "Bounced Address",
+                "sg_event_id": "ZHJvcC0xMDk5NDkxOS1MUnpYbF9OSFN0T0doUTRrb2ZTbV9BLTA",
+                "sg_message_id": "LRzXl_NHStOGhQ4kofSm_A.filterdrecv-p3mdw1-756b745b58-kmzbl-18-5F5FC76C-9.0",
+                "smtp-id": "<LRzXl_NHStOGhQ4kofSm_A@ismtpd0039p1iad1.sendgrid.net>",
+                "timestamp": 1600112492,
+            }
+        ],
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    + "\r\n"
+)
+
+
+@pytest.fixture()
+def test_db():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(autocommit=False, autoflush=False, expire_on_commit=False, bind=engine)
+    db = session_factory()
+    try:
+        yield db
+    finally:
+        db.close()
+        engine.dispose()
+
+
+@pytest.fixture()
+def client(test_db, monkeypatch):
+    api_main.app.dependency_overrides[get_db] = lambda: test_db
+    monkeypatch.setattr(Config, "get_twilio_auth_token", classmethod(lambda cls: "twilio-token"))
+    monkeypatch.setattr(Config, "get_sendgrid_event_webhook_public_key", classmethod(lambda cls: SENDGRID_PUBLIC_KEY))
+    with TestClient(api_main.app) as test_client:
+        yield test_client
+    api_main.app.dependency_overrides.clear()
+
+
+def _seed_notification_log(db, message_id: str, channel: NotificationChannel):
+    user = User(email="webhook@example.com")
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    case = Case(
+        user_id=user.id,
+        case_number="CASE-WEBHOOK",
+        case_type="civil",
+        jurisdiction="Delhi",
+        status=CaseStatus.ACTIVE,
+        title="Webhook Case",
+    )
+    db.add(case)
+    db.commit()
+    db.refresh(case)
+
+    deadline = CaseDeadline(
+        user_id=user.id,
+        case_id=case.id,
+        case_title="Webhook Case",
+        deadline_date=datetime.now(timezone.utc) + timedelta(days=10),
+        deadline_type="appeal",
+    )
+    db.add(deadline)
+    db.commit()
+    db.refresh(deadline)
+
+    log = NotificationLog(
+        deadline_id=deadline.id,
+        user_id=user.id,
+        channel=channel,
+        recipient="recipient@example.com",
+        days_before=10,
+        status=NotificationStatus.SENT,
+        message_id=message_id,
+        sent_at=datetime.now(timezone.utc),
+    )
+    db.add(log)
+    db.commit()
+    db.refresh(log)
+    return log
+
+
+def test_twilio_webhook_marks_notification_delivered(client, test_db):
+    message_sid = "SM123456789"
+    log = _seed_notification_log(test_db, message_sid, NotificationChannel.SMS)
+
+    params = {
+        "MessageSid": message_sid,
+        "MessageStatus": "delivered",
+        "SmsSid": message_sid,
+        "SmsStatus": "delivered",
+    }
+    signature = RequestValidator("twilio-token").compute_signature("http://testserver/api/v1/webhooks/twilio", params)
+
+    response = client.post(
+        "/api/v1/webhooks/twilio",
+        data=params,
+        headers={"X-Twilio-Signature": signature},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is True
+    assert body["updated"] is True
+
+    refreshed = test_db.query(NotificationLog).filter(NotificationLog.id == log.id).one()
+    assert refreshed.status == NotificationStatus.DELIVERED
+    assert refreshed.delivered_at is not None
+    assert refreshed.sent_at is not None
+    assert refreshed.failed_at is None
+
+
+def test_sendgrid_webhook_marks_notification_failed(client, test_db):
+    message_id = "LRzXl_NHStOGhQ4kofSm_A.filterdrecv-p3mdw1-756b745b58-kmzbl-18-5F5FC76C-9.0"
+    log = _seed_notification_log(test_db, message_id, NotificationChannel.EMAIL)
+
+    response = client.post(
+        "/api/v1/webhooks/sendgrid",
+        content=SENDGRID_PAYLOAD.encode("utf-8"),
+        headers={
+            "X-Twilio-Email-Event-Webhook-Signature": SENDGRID_SIGNATURE,
+            "X-Twilio-Email-Event-Webhook-Timestamp": SENDGRID_TIMESTAMP,
+            "Content-Type": "application/json",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is True
+    assert body["events"] == 1
+    assert body["updated"] == 1
+
+    refreshed = test_db.query(NotificationLog).filter(NotificationLog.id == log.id).one()
+    assert refreshed.status == NotificationStatus.FAILED
+    assert refreshed.failed_at is not None
+    assert "Bounced Address" in (refreshed.error_message or "")
+    assert refreshed.delivered_at is None


### PR DESCRIPTION
Implemented the webhook flow end to end. Twilio and SendGrid callbacks now live in notifications.py and notifications.py, are registered in main.py, and are exempted from CSRF/idempotency in main.py and idempotency.py. The notification model now has DELIVERED and failed_at in notifications.py and notifications.py, and the CRUD layer can update rows by message_id with the right timestamp transitions in notifications.py. The SendGrid webhook public key hook is in config.py.

Added fixture coverage in test_notification_webhooks.py and test_notification_webhooks.py for a signed Twilio delivered callback and a signed SendGrid failed callback. I validated syntax with py_compile across the touched files; a live pytest run was blocked in this environment because the available Python install is missing sqlalchemy, and the Windows py launcher is not present.


closes #968