### PR TITLE
[BUG] publish_timeline_event_best_effort can leak tasks / create untr…

### DIFF
--- a/services/timeline_realtime.py
+++ b/services/timeline_realtime.py
@@ -4,7 +4,7 @@ import asyncio
 import os
 import threading
 from dataclasses import dataclass, field
-from typing import Any, Dict, Set
+from typing import Any, Dict, Optional, Set
 
 import structlog
 
@@ -149,10 +149,24 @@ timeline_queue_maxsize = int(os.getenv("TIMELINE_REALTIME_QUEUE_MAXSIZE", "100")
 timeline_realtime_bus = TimelineRealtimeBus(queue_maxsize=timeline_queue_maxsize)
 
 
-def publish_timeline_event_best_effort(payload: Dict[str, Any]) -> None:
+def publish_timeline_event_best_effort(payload: Dict[str, Any]) -> Optional[asyncio.Task[Any]]:
     """Publish a timeline event without depending on the caller's loop state."""
     case_id = payload["case_id"]
     publish_coro = timeline_realtime_bus.publish(case_id=case_id, payload=payload)
+
+    def _log_publish_task_failure(task: asyncio.Task[Any]) -> None:
+        if task.cancelled():
+            return
+
+        exc = task.exception()
+        if exc is not None:
+            logger.error(
+                "timeline_realtime_publish_failed",
+                case_id=case_id,
+                error_type=type(exc).__name__,
+                error=str(exc),
+                exc_info=exc,
+            )
 
     try:
         loop = asyncio.get_running_loop()
@@ -160,11 +174,13 @@ def publish_timeline_event_best_effort(payload: Dict[str, Any]) -> None:
         loop = None
 
     if loop is not None:
-        loop.create_task(publish_coro)
-        return
+        task = loop.create_task(publish_coro)
+        task.add_done_callback(_log_publish_task_failure)
+        return task
 
     fallback_loop = asyncio.new_event_loop()
     try:
         fallback_loop.run_until_complete(publish_coro)
     finally:
         fallback_loop.close()
+    return None

--- a/tests/test_timeline_realtime.py
+++ b/tests/test_timeline_realtime.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from core.timeline_payloads import TimelineEventPayload
-from services.timeline_realtime import TimelineRealtimeBus
+from services.timeline_realtime import TimelineRealtimeBus, publish_timeline_event_best_effort
 from pydantic import ValidationError
 
 
@@ -207,5 +207,42 @@ def test_publish_keeps_latest_message_when_queue_is_full():
             assert mock_warning.call_count == 1
             assert mock_warning.call_args.kwargs["policy"] == "drop_oldest_keep_latest"
             assert mock_warning.call_args.kwargs["case_id"] == 7
+
+    asyncio.run(scenario())
+
+
+def test_publish_timeline_event_best_effort_logs_async_task_failures():
+    async def scenario() -> None:
+        payload = {
+            "schema_version": 2,
+            "type": "timeline_event",
+            "case_id": 7,
+            "event_type": "deadline_created",
+            "description": "Manual deadline added",
+            "timestamp": datetime(2026, 5, 22, 10, 30, tzinfo=timezone.utc),
+            "metadata": {},
+            "event_id": 555,
+        }
+
+        async def failing_publish(*args, **kwargs):
+            raise ValueError("boom")
+
+        with patch.object(
+            TimelineRealtimeBus,
+            "publish",
+            failing_publish,
+        ):
+            with patch("services.timeline_realtime.logger.error") as mock_error:
+                task = publish_timeline_event_best_effort(payload)
+                assert task is not None
+
+                with pytest.raises(ValueError, match="boom"):
+                    await task
+
+                assert mock_error.call_count == 1
+                assert mock_error.call_args.args[0] == "timeline_realtime_publish_failed"
+                assert mock_error.call_args.kwargs["case_id"] == 7
+                assert mock_error.call_args.kwargs["error_type"] == "ValueError"
+                assert mock_error.call_args.kwargs["error"] == "boom"
 
     asyncio.run(scenario())


### PR DESCRIPTION
Updated timeline_realtime.py so `publish_timeline_event_best_effort` now returns the created task on the running-loop path and attaches a done-callback that logs any task exception under `timeline_realtime_publish_failed`. The fallback path still runs synchronously, but the fire-and-forget path no longer drops failures on the floor.

I also added a regression test in test_timeline_realtime.py that forces the async publish task to fail and verifies the error gets logged.

closes #1018