### PR TITLE
[BUG] Timeline bus uses loop.call_soon_threadsafe

### DIFF
--- a/services/timeline_realtime.py
+++ b/services/timeline_realtime.py
@@ -14,9 +14,16 @@ from core.timeline_payloads import TimelineEventPayload
 logger = structlog.get_logger(__name__)
 
 
+@dataclass(frozen=True)
+class _SubscriberConnection:
+    queue: "asyncio.Queue[Dict[str, Any]]"
+    loop: asyncio.AbstractEventLoop
+    thread_id: int
+
+
 @dataclass
 class _CaseChannel:
-    connections: Set[tuple["asyncio.Queue[Dict[str, Any]]", asyncio.AbstractEventLoop]] = field(default_factory=set)
+    connections: Set[_SubscriberConnection] = field(default_factory=set)
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     dropped_messages: int = 0
 
@@ -101,8 +108,9 @@ class TimelineRealtimeBus:
         channel = await self._get_or_create_channel(case_id)
         q: asyncio.Queue[Dict[str, Any]] = asyncio.Queue(maxsize=self._queue_maxsize)
         loop = asyncio.get_running_loop()
+        subscriber = _SubscriberConnection(queue=q, loop=loop, thread_id=threading.get_ident())
         async with channel.lock:
-            channel.connections.add((q, loop))
+            channel.connections.add(subscriber)
         return q
 
     async def unsubscribe(self, case_id: int, q: asyncio.Queue[Dict[str, Any]]) -> None:
@@ -111,7 +119,7 @@ class TimelineRealtimeBus:
             if channel is None:
                 return
         async with channel.lock:
-            channel.connections = {subscriber for subscriber in channel.connections if subscriber[0] is not q}
+            channel.connections = {subscriber for subscriber in channel.connections if subscriber.queue is not q}
             if not channel.connections:
                 async with self._global_lock:
                     if self._channels.get(case_id) is channel:
@@ -126,12 +134,27 @@ class TimelineRealtimeBus:
         validated_payload = TimelineEventPayload.model_validate(payload)
         message = validated_payload.model_dump(mode="json")
         current_loop = asyncio.get_running_loop()
+        current_thread_id = threading.get_ident()
         async with channel.lock:
             targets = list(channel.connections)
+            dead_targets = [subscriber for subscriber in targets if subscriber.loop.is_closed()]
+            if dead_targets:
+                channel.connections.difference_update(dead_targets)
+                logger.warning(
+                    "timeline_realtime_dead_subscribers_removed",
+                    case_id=case_id,
+                    dead_subscribers=len(dead_targets),
+                    subscriber_count=len(targets),
+                    remaining_subscribers=len(channel.connections),
+                )
+                targets = [subscriber for subscriber in targets if not subscriber.loop.is_closed()]
 
         # fan-out outside lock
-        for q, loop in targets:
-            deliver = lambda q=q, loop=loop: self._deliver_message(
+        for subscriber in targets:
+            q = subscriber.queue
+            loop = subscriber.loop
+
+            deliver = lambda q=q: self._deliver_message(
                 queue=q,
                 message=message,
                 case_id=case_id,
@@ -142,7 +165,35 @@ class TimelineRealtimeBus:
             if loop is current_loop:
                 deliver()
             else:
-                loop.call_soon_threadsafe(deliver)
+                logger.debug(
+                    "timeline_realtime_cross_loop_delivery",
+                    case_id=case_id,
+                    subscriber_count=len(targets),
+                    target_loop_running=loop.is_running(),
+                    target_loop_closed=loop.is_closed(),
+                    target_thread_id=subscriber.thread_id,
+                    publisher_thread_id=current_thread_id,
+                )
+
+                if loop.is_closed():
+                    continue
+
+                try:
+                    loop.call_soon_threadsafe(deliver)
+                except RuntimeError:
+                    if not loop.is_closed():
+                        raise
+
+                    async with channel.lock:
+                        if subscriber in channel.connections:
+                            channel.connections.remove(subscriber)
+                            logger.warning(
+                                "timeline_realtime_dead_subscriber_removed",
+                                case_id=case_id,
+                                subscriber_count=len(channel.connections),
+                                target_thread_id=subscriber.thread_id,
+                                publisher_thread_id=current_thread_id,
+                            )
 
 
 timeline_queue_maxsize = int(os.getenv("TIMELINE_REALTIME_QUEUE_MAXSIZE", "100"))

--- a/services/timeline_realtime.py
+++ b/services/timeline_realtime.py
@@ -4,7 +4,7 @@ import asyncio
 import os
 import threading
 from dataclasses import dataclass, field
-from typing import Any, Dict, Set
+from typing import Any, Dict, Optional, Set
 
 import structlog
 
@@ -149,10 +149,24 @@ timeline_queue_maxsize = int(os.getenv("TIMELINE_REALTIME_QUEUE_MAXSIZE", "100")
 timeline_realtime_bus = TimelineRealtimeBus(queue_maxsize=timeline_queue_maxsize)
 
 
-def publish_timeline_event_best_effort(payload: Dict[str, Any]) -> None:
+def publish_timeline_event_best_effort(payload: Dict[str, Any]) -> Optional[asyncio.Task[Any]]:
     """Publish a timeline event without depending on the caller's loop state."""
     case_id = payload["case_id"]
     publish_coro = timeline_realtime_bus.publish(case_id=case_id, payload=payload)
+
+    def _log_publish_task_failure(task: asyncio.Task[Any]) -> None:
+        if task.cancelled():
+            return
+
+        exc = task.exception()
+        if exc is not None:
+            logger.error(
+                "timeline_realtime_publish_failed",
+                case_id=case_id,
+                error_type=type(exc).__name__,
+                error=str(exc),
+                exc_info=exc,
+            )
 
     try:
         loop = asyncio.get_running_loop()
@@ -160,11 +174,13 @@ def publish_timeline_event_best_effort(payload: Dict[str, Any]) -> None:
         loop = None
 
     if loop is not None:
-        loop.create_task(publish_coro)
-        return
+        task = loop.create_task(publish_coro)
+        task.add_done_callback(_log_publish_task_failure)
+        return task
 
     fallback_loop = asyncio.new_event_loop()
     try:
         fallback_loop.run_until_complete(publish_coro)
     finally:
         fallback_loop.close()
+    return None

--- a/tests/test_timeline_realtime.py
+++ b/tests/test_timeline_realtime.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from core.timeline_payloads import TimelineEventPayload
-from services.timeline_realtime import TimelineRealtimeBus
+from services.timeline_realtime import TimelineRealtimeBus, publish_timeline_event_best_effort
 from pydantic import ValidationError
 
 
@@ -207,5 +207,42 @@ def test_publish_keeps_latest_message_when_queue_is_full():
             assert mock_warning.call_count == 1
             assert mock_warning.call_args.kwargs["policy"] == "drop_oldest_keep_latest"
             assert mock_warning.call_args.kwargs["case_id"] == 7
+
+    asyncio.run(scenario())
+
+
+def test_publish_timeline_event_best_effort_logs_async_task_failures():
+    async def scenario() -> None:
+        payload = {
+            "schema_version": 2,
+            "type": "timeline_event",
+            "case_id": 7,
+            "event_type": "deadline_created",
+            "description": "Manual deadline added",
+            "timestamp": datetime(2026, 5, 22, 10, 30, tzinfo=timezone.utc),
+            "metadata": {},
+            "event_id": 555,
+        }
+
+        async def failing_publish(*args, **kwargs):
+            raise ValueError("boom")
+
+        with patch.object(
+            TimelineRealtimeBus,
+            "publish",
+            failing_publish,
+        ):
+            with patch("services.timeline_realtime.logger.error") as mock_error:
+                task = publish_timeline_event_best_effort(payload)
+                assert task is not None
+
+                with pytest.raises(ValueError, match="boom"):
+                    await task
+
+                assert mock_error.call_count == 1
+                assert mock_error.call_args.args[0] == "timeline_realtime_publish_failed"
+                assert mock_error.call_args.kwargs["case_id"] == 7
+                assert mock_error.call_args.kwargs["error_type"] == "ValueError"
+                assert mock_error.call_args.kwargs["error"] == "boom"
 
     asyncio.run(scenario())

--- a/tests/test_timeline_realtime.py
+++ b/tests/test_timeline_realtime.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from core.timeline_payloads import TimelineEventPayload
-from services.timeline_realtime import TimelineRealtimeBus, publish_timeline_event_best_effort
+from services.timeline_realtime import TimelineRealtimeBus, _SubscriberConnection, publish_timeline_event_best_effort
 from pydantic import ValidationError
 
 
@@ -207,6 +207,127 @@ def test_publish_keeps_latest_message_when_queue_is_full():
             assert mock_warning.call_count == 1
             assert mock_warning.call_args.kwargs["policy"] == "drop_oldest_keep_latest"
             assert mock_warning.call_args.kwargs["case_id"] == 7
+
+    asyncio.run(scenario())
+
+
+def test_publish_prunes_closed_subscribers_before_fanout():
+    bus = TimelineRealtimeBus()
+
+    class FakeLiveLoop:
+        def is_closed(self):
+            return False
+
+        def is_running(self):
+            return True
+
+        def call_soon_threadsafe(self, callback):
+            callback()
+
+    async def scenario() -> None:
+        queue = await bus.subscribe(7)
+        channel = await bus._get_or_create_channel(7)
+
+        dead_loop = asyncio.new_event_loop()
+        dead_loop.close()
+        fake_live_loop = FakeLiveLoop()
+
+        async with channel.lock:
+            channel.connections.add(
+                _SubscriberConnection(
+                    queue=asyncio.Queue(maxsize=1),
+                    loop=dead_loop,
+                    thread_id=999,
+                )
+            )
+            channel.connections.add(
+                _SubscriberConnection(
+                    queue=asyncio.Queue(maxsize=1),
+                    loop=fake_live_loop,
+                    thread_id=1000,
+                )
+            )
+
+        with patch("services.timeline_realtime.logger.warning") as mock_warning:
+            await bus.publish(
+                7,
+                {
+                    "schema_version": 2,
+                    "type": "timeline_event",
+                    "case_id": 7,
+                    "event_type": "deadline_created",
+                    "description": "Manual deadline added",
+                    "timestamp": datetime(2026, 5, 22, 10, 30, tzinfo=timezone.utc),
+                    "metadata": {},
+                    "event_id": 555,
+                },
+            )
+
+            payload = await queue.get()
+            validated = TimelineEventPayload.model_validate(payload)
+            assert validated.case_id == 7
+            assert len(channel.connections) == 2
+            assert mock_warning.call_args.kwargs["dead_subscribers"] == 1
+            assert mock_warning.call_args.kwargs["remaining_subscribers"] == 2
+
+        dead_loop.close()
+
+    asyncio.run(scenario())
+
+
+def test_publish_logs_cross_loop_delivery_metadata():
+    bus = TimelineRealtimeBus()
+
+    class FakeLoop:
+        def __init__(self):
+            self.calls = []
+
+        def is_closed(self):
+            return False
+
+        def is_running(self):
+            return True
+
+        def call_soon_threadsafe(self, callback):
+            self.calls.append(callback)
+            callback()
+
+    async def scenario() -> None:
+        channel = await bus._get_or_create_channel(7)
+        target_loop = FakeLoop()
+        queue = asyncio.Queue(maxsize=1)
+
+        async with channel.lock:
+            channel.connections.add(
+                _SubscriberConnection(
+                    queue=queue,
+                    loop=target_loop,
+                    thread_id=12345,
+                )
+            )
+
+        with patch("services.timeline_realtime.logger.debug") as mock_debug:
+            await bus.publish(
+                7,
+                {
+                    "schema_version": 2,
+                    "type": "timeline_event",
+                    "case_id": 7,
+                    "event_type": "deadline_created",
+                    "description": "Manual deadline added",
+                    "timestamp": datetime(2026, 5, 22, 10, 30, tzinfo=timezone.utc),
+                    "metadata": {},
+                    "event_id": 555,
+                },
+            )
+
+            payload = await queue.get()
+            validated = TimelineEventPayload.model_validate(payload)
+            assert validated.case_id == 7
+            assert target_loop.calls
+            assert mock_debug.call_args.kwargs["subscriber_count"] == 1
+            assert mock_debug.call_args.kwargs["target_loop_running"] is True
+            assert mock_debug.call_args.kwargs["target_loop_closed"] is False
 
     asyncio.run(scenario())
 


### PR DESCRIPTION
I tightened the realtime bus in timeline_realtime.py: each subscriber now carries explicit loop and thread identity, publish logs cross-loop delivery metadata, and closed loops are pruned before fan-out so dead event loops do not keep getting scheduled. The fan-out path still uses `call_soon_threadsafe` for cross-loop delivery, but now it is guarded and self-healing if a loop closes between snapshot and dispatch.

I also added regression coverage in test_timeline_realtime.py for dead-subscriber pruning and cross-loop logging. `python -m py_compile timeline_realtime.py tests/test_timeline_realtime.py` passed. The narrow pytest run is still blocked during collection by an unrelated Pydantic model issue in timeline_payloads.py (`CURRENT_SCHEMA_VERSION` needs a `ClassVar` under this environment).


closes #1019