### PR TITLE
Convert heavy I/O pipelines to async/non-blocking (PDFs, OCR, LLM calls)

### DIFF
--- a/core/app_utils.py
+++ b/core/app_utils.py
@@ -1340,6 +1340,84 @@ def safe_llm_call(
     return None, f"An unexpected error occurred after {retries} attempts: {last_error}"
 
 
+async def safe_llm_call_async(
+    client: OpenAI,
+    model: str,
+    messages: List[Dict[str, str]],
+    max_tokens: int,
+    temperature: float,
+    timeout: Optional[float] = None,
+    retries: Optional[int] = None
+) -> Tuple[Optional[str], Optional[str]]:
+    """Async wrapper around `safe_llm_call` that offloads blocking client calls to a thread.
+
+    This keeps asyncio event loops responsive while still leveraging the same
+    retry and error-handling semantics as the synchronous helper.
+    """
+    import asyncio as _asyncio
+    import time as _time
+    import openai as _openai
+
+    if timeout is None:
+        timeout = Config.AI_REQUEST_TIMEOUT
+    if retries is None:
+        retries = Config.AI_MAX_RETRIES
+
+    last_error = None
+
+    for attempt in range(retries):
+        try:
+            # Offload the blocking client call to a thread
+            def _call():
+                return client.chat.completions.create(
+                    model=model,
+                    messages=messages,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    timeout=timeout,
+                )
+
+            response = await _asyncio.to_thread(_call)
+            if hasattr(response, 'choices') and response.choices:
+                return response.choices[0].message.content.strip(), None
+            return None, "Empty response from LLM"
+        except _openai.AuthenticationError:
+            return None, "Authentication failed. Please check your API key in the configuration."
+        except _openai.RateLimitError:
+            if attempt < retries - 1:
+                wait_time = Config.AI_RETRY_BACKOFF_BASE ** attempt
+                logging.warning(f"Rate limit hit. Retrying in {wait_time}s... (Attempt {attempt + 1}/{retries})")
+                await _asyncio.sleep(wait_time)
+                continue
+            return None, "Rate limit exceeded. Please try again in a few minutes."
+        except _openai.APITimeoutError:
+            if attempt < retries - 1:
+                logging.warning(f"Request timed out. Retrying... (Attempt {attempt + 1}/{retries})")
+                continue
+            return None, "The request timed out. The AI server might be busy or your connection is slow."
+        except _openai.APIConnectionError:
+            if attempt < retries - 1:
+                logging.warning(f"Connection error. Retrying... (Attempt {attempt + 1}/{retries})")
+                await _asyncio.sleep(1)
+                continue
+            return None, "Could not connect to the AI server. Please check your internet connection."
+        except _openai.APIStatusError as e:
+            if e.status_code == 402:
+                return None, "AI Service Error: Out of credits. Please top up your provider account."
+            if attempt < retries - 1:
+                await _asyncio.sleep(1)
+                continue
+            return None, f"AI Service Error (HTTP {e.status_code}): {str(e)}"
+        except Exception as e:
+            last_error = str(e)
+            logging.exception(f"Unexpected async LLM API Error (Attempt {attempt + 1}): {str(e)}")
+            if attempt < retries - 1:
+                await _asyncio.sleep(0.5)
+                continue
+
+    return None, f"An unexpected error occurred after {retries} attempts: {last_error}"
+
+
 def build_draft_prompt(remedies, language):
     """Build a prompt for drafting a formal legal document based on remedies."""
     remedy_summary = json.dumps(remedies, indent=2)

--- a/core/ocr_engine.py
+++ b/core/ocr_engine.py
@@ -479,3 +479,75 @@ def extract_text_from_image(
     ocr = OCREngine()
     result = ocr.extract_text(image, languages, preprocess)
     return result.get('text', '')
+
+
+# Async non-blocking wrappers
+import asyncio
+
+
+async def extract_text_from_image_async(
+    image: np.ndarray,
+    languages: list = ['eng'],
+    preprocess: bool = True
+) -> str:
+    """Async wrapper for quick text extraction that offloads work to a thread.
+
+    This keeps async event-loops responsive when performing OCR using
+    blocking C-extensions like Tesseract and OpenCV.
+    """
+    ocr = OCREngine()
+    result = await asyncio.to_thread(ocr.extract_text, image, languages, preprocess)
+    return result.get('text', '')
+
+
+class AsyncOCREngine(OCREngine):
+    """Provides async equivalents for heavy OCR operations."""
+
+    async def extract_text_async(self, image: np.ndarray, languages: list = ['eng'], preprocess: bool = True, config: Optional[str] = None) -> Dict[str, Any]:
+        return await asyncio.to_thread(self.extract_text, image, languages, preprocess, config)
+
+    async def extract_text_with_layout_async(self, image: np.ndarray, languages: list = ['eng']) -> Dict[str, Any]:
+        return await asyncio.to_thread(self.extract_text_with_layout, image, languages)
+
+    async def extract_handwriting_async(self, image: np.ndarray, languages: list = ['eng']) -> Dict[str, Any]:
+        return await asyncio.to_thread(self.extract_handwriting, image, languages)
+
+    async def batch_process_images_async(self, image_paths: list, languages: list = ['eng'], callback=None) -> list:
+        """Process multiple images concurrently without blocking the event loop.
+
+        It uses a threadpool for CPU-bound image processing and OCR.
+        """
+        loop = asyncio.get_running_loop()
+        tasks = []
+        results = []
+
+        async def _process(path):
+            try:
+                image = await loop.run_in_executor(None, ImageProcessor.load_image, path)
+                if image is None:
+                    return {'file': path, 'success': False, 'error': 'Failed to load image'}
+                res = await asyncio.to_thread(self.extract_text, image, languages)
+                res['file'] = path
+                return res
+            except Exception as e:
+                return {'file': path, 'success': False, 'error': str(e)}
+
+        for path in image_paths:
+            tasks.append(asyncio.create_task(_process(path)))
+
+        for coro in asyncio.as_completed(tasks):
+            r = await coro
+            results.append(r)
+            if callback:
+                try:
+                    callback(len(results), len(image_paths), r)
+                except Exception:
+                    pass
+
+        return results
+
+    async def detect_language_async(self, image: np.ndarray) -> Dict[str, Any]:
+        return await asyncio.to_thread(self.detect_language, image)
+
+    async def improve_ocr_quality_async(self, image: np.ndarray, languages: list = ['eng'], iterations: int = 3) -> Dict[str, Any]:
+        return await asyncio.to_thread(self.improve_ocr_quality, image, languages, iterations)

--- a/core/rag_engine.py
+++ b/core/rag_engine.py
@@ -339,3 +339,95 @@ ANSWER IN {language} (include citations if possible):
         except Exception as e:
             LOGGER.error(f"Error querying RAG engine: {e}")
             return f"An error occurred while trying to answer your question: {str(e)}"
+
+    async def async_query(self, question: str, language: str, openai_client, chat_history: Optional[List[Dict[str, str]]] = None) -> str:
+        """Async version of `query` that uses an async LLM helper to avoid blocking the event loop."""
+        if not self.vector_store:
+            return "Please wait for the document to finish processing before asking questions."
+
+        try:
+            LOGGER.info(f"(async) Retrieving context for question: {question}")
+            retrieved = self.retrieve_with_scores(question, k=5)
+
+            if not retrieved:
+                LOGGER.info("Semantic search returned no results, trying keyword fallback")
+                keyword_results = self._keyword_fallback_search(question)
+                if keyword_results:
+                    context = "\n\n---\n\n".join(keyword_results)
+                    citations = []
+                    LOGGER.info(f"Keyword fallback found {len(keyword_results)} results")
+                else:
+                    return "I couldn't find relevant information in the document to answer your question."
+            else:
+                scores = [r.get("score", 0.0) for r in retrieved]
+                max_score = max(scores) if scores else 0.0
+                if max_score <= 1.0 and max_score >= -1.0:
+                    norm_scores = [max(0.0, min(1.0, (s + 1) / 2 if s < 0.0 else s)) for s in scores]
+                else:
+                    norm_scores = [max(0.0, min(1.0, float(s))) for s in scores]
+
+                confidence = max(norm_scores) if norm_scores else 0.0
+                threshold = float(getattr(Config, "RAG_CONFIDENCE_THRESHOLD", 0.2))
+                LOGGER.info(f"Retrieval confidence: {confidence:.3f} (threshold {threshold})")
+                if confidence < threshold:
+                    return "I cannot find sufficient evidence in the document to answer that question."
+
+                parts = []
+                citations = []
+                for r, s in zip(retrieved, norm_scores):
+                    meta = r.get("metadata", {})
+                    citation = f"[source:{meta.get('source_hash','unknown')}#chunk:{meta.get('chunk_index',0)}]"
+                    excerpt = meta.get("excerpt") or (r.get("content")[:240] + "...")
+                    parts.append(f"{excerpt}\n\nCitation: {citation} (score={s:.3f})")
+                    citations.append(citation)
+
+                context = "\n\n---\n\n".join(parts)
+
+            history_str = ""
+            if chat_history:
+                recent_history = chat_history[-6:]
+                history_str = "\n".join([f"{m['role'].upper()}: {m['content']}" for m in recent_history])
+
+            prompt = f"""
+You are LegalEase AI, an expert judicial researcher. 
+Your goal is to provide accurate, context-grounded answers to user questions about a specific legal document.
+
+STRICT GUIDELINES:
+1. Answer ONLY based on the provided CONTEXT. If the answer is not in the context, say "I cannot find the answer to this in the document."
+2. CITATIONS: Whenever possible, quote specific sentences or phrases from the document to support your answer.
+3. CONVERSATION: Use the RECENT CHAT HISTORY to understand follow-up questions (e.g., "What about the other person?").
+4. LANGUAGE: Provide your final answer ONLY in the {language} language.
+
+RECENT CHAT HISTORY:
+{history_str}
+
+CONEXT FROM DOCUMENT:
+{context}
+
+USER QUESTION:
+{question}
+
+ANSWER IN {language} (include citations if possible):
+"""
+
+            LOGGER.info("(async) Generating response from LLM...")
+            from core.app_utils import safe_llm_call_async
+            answer, error = await safe_llm_call_async(
+                client=openai_client,
+                model=Config.DEFAULT_MODEL,
+                messages=[
+                    {"role": "system", "content": f"You are a helpful legal researcher. Output only in {language}."},
+                    {"role": "user", "content": prompt}
+                ],
+                max_tokens=600,
+                temperature=0.1,
+            )
+
+            if error:
+                return f"AI Service Error: {error}"
+
+            return answer
+
+        except Exception as e:
+            LOGGER.error(f"Error querying RAG engine (async): {e}")
+            return f"An error occurred while trying to answer your question: {str(e)}"


### PR DESCRIPTION
## Description

Convert heavy blocking I/O for OCR and LLM calls into non-blocking async-friendly helpers to improve responsiveness and allow concurrent processing in async application code.
Add async wrappers that offload blocking C-extension and network calls to threads (using asyncio.to_thread / run_in_executor), preserving existing sync APIs for compatibility.

## Why

Tesseract (pytesseract) and OpenCV are blocking and can stall async event loops.
LLM client calls may block the event loop if used directly; providing an async wrapper keeps high-concurrency servers responsive.
Provides a clear migration path: async helpers can be adopted incrementally.

# ISSUE RESOLVED #1046 

