### PR TITLE
Harden authentication: OTP/JWT replay, rate-limits, and token revocation

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -130,6 +130,14 @@ def revoke_jwt_token(token: str) -> bool:
 
             if not is_token_revoked(db, jti):
                 revoke_token(db, jti, expires_at)
+                # Mark in-memory revocation cache if jwt_auth cache is available
+                try:
+                    import api.jwt_auth as _jwt_mod
+                    now = datetime.now(timezone.utc).timestamp()
+                    _jwt_mod._REVOCATION_CACHE[jti] = (True, now)
+                except Exception:
+                    # non-fatal; cache may not be present in some test envs
+                    pass
         return True
     except Exception:
         return False

--- a/api/jwt_auth.py
+++ b/api/jwt_auth.py
@@ -190,6 +190,9 @@ def revoke_jwt_token(token: str) -> bool:
         with SessionLocal() as db:
             if not is_token_revoked(db, jti):
                 revoke_token(db, jti, expires_at)
+                # Ensure in-memory cache marks this JTI as revoked immediately
+                now = datetime.now(timezone.utc).timestamp()
+                _REVOCATION_CACHE[jti] = (True, now)
         return True
     except Exception as exc:
         logger.error("revoke_jwt_token_failed", error=str(exc))

--- a/api/main.py
+++ b/api/main.py
@@ -164,6 +164,13 @@ def create_app() -> FastAPI:
     async def startup_event():
         """Initialize on startup"""
         initialize_observability_for_environment()
+        # Attempt to instrument FastAPI with OpenTelemetry (if available)
+        try:
+            from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+            FastAPIInstrumentor().instrument_app(app)
+            logger.info("fastapi_instrumented")
+        except Exception:
+            logger.debug("fastapi_instrumentation_unavailable_or_failed")
         logger.info(
             "API Starting",
             version=settings.API_VERSION,

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -17,6 +17,8 @@ from api.models import TokenResponse, APIKeyCreate, APIKeyResponse
 from api.limiter import RateLimit
 import structlog
 from core.log_redaction import mask_email
+from fastapi import Request
+from api.auth import revoke_jwt_token as api_revoke_jwt
 
 _pwd_ctx = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
@@ -188,3 +190,33 @@ async def get_current_user_info(
         "role": current_user.role,
         "subscription_tier": "pro"
     }
+
+
+
+
+@router.post(
+    "/logout",
+    summary="Logout and revoke current JWT token",
+    dependencies=[Depends(RateLimit(use_auth_defaults=True))]
+)
+async def logout(request: Request) -> dict:
+    """Revoke the JWT presented in Authorization header (if any)."""
+    auth = request.headers.get("Authorization") or request.headers.get("authorization")
+    token = None
+    if auth and auth.lower().startswith("bearer "):
+        token = auth.split(None, 1)[1].strip()
+
+    if not token:
+        # Nothing to revoke, but return success to avoid token probing
+        return {"status": "ok", "revoked": False}
+
+    try:
+        success = api_revoke_jwt(token)
+        if success:
+            logger.info("api_logout_revoked")
+        else:
+            logger.info("api_logout_no_revoke_needed")
+        return {"status": "ok", "revoked": bool(success)}
+    except Exception as e:
+        logger.error("api_logout_failed", error=str(e))
+        return {"status": "error", "revoked": False}

--- a/auth.py
+++ b/auth.py
@@ -333,9 +333,13 @@ def verify_otp_and_create_token(email: str, otp: str) -> Tuple[bool, str, Option
             )
             return False, GENERIC_OTP_FAILURE, None
 
-        # OTP is valid - reset failed attempts and mark as used
+        # OTP is valid - reset failed attempts and atomically mark as used
         reset_otp_failed_attempts(db, otp_record.id)
-        mark_otp_as_used(db, otp_record.id)
+        marked = mark_otp_as_used(db, otp_record.id)
+        if not marked:
+            # Another process may have consumed this OTP concurrently.
+            logger.warning("otp_replay_detected", recipient=mask_email(email))
+            return False, GENERIC_OTP_FAILURE, None
 
         # Get or create user
         user = get_user_by_email(db, email)

--- a/core/app_utils.py
+++ b/core/app_utils.py
@@ -1340,6 +1340,84 @@ def safe_llm_call(
     return None, f"An unexpected error occurred after {retries} attempts: {last_error}"
 
 
+async def safe_llm_call_async(
+    client: OpenAI,
+    model: str,
+    messages: List[Dict[str, str]],
+    max_tokens: int,
+    temperature: float,
+    timeout: Optional[float] = None,
+    retries: Optional[int] = None
+) -> Tuple[Optional[str], Optional[str]]:
+    """Async wrapper around `safe_llm_call` that offloads blocking client calls to a thread.
+
+    This keeps asyncio event loops responsive while still leveraging the same
+    retry and error-handling semantics as the synchronous helper.
+    """
+    import asyncio as _asyncio
+    import time as _time
+    import openai as _openai
+
+    if timeout is None:
+        timeout = Config.AI_REQUEST_TIMEOUT
+    if retries is None:
+        retries = Config.AI_MAX_RETRIES
+
+    last_error = None
+
+    for attempt in range(retries):
+        try:
+            # Offload the blocking client call to a thread
+            def _call():
+                return client.chat.completions.create(
+                    model=model,
+                    messages=messages,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    timeout=timeout,
+                )
+
+            response = await _asyncio.to_thread(_call)
+            if hasattr(response, 'choices') and response.choices:
+                return response.choices[0].message.content.strip(), None
+            return None, "Empty response from LLM"
+        except _openai.AuthenticationError:
+            return None, "Authentication failed. Please check your API key in the configuration."
+        except _openai.RateLimitError:
+            if attempt < retries - 1:
+                wait_time = Config.AI_RETRY_BACKOFF_BASE ** attempt
+                logging.warning(f"Rate limit hit. Retrying in {wait_time}s... (Attempt {attempt + 1}/{retries})")
+                await _asyncio.sleep(wait_time)
+                continue
+            return None, "Rate limit exceeded. Please try again in a few minutes."
+        except _openai.APITimeoutError:
+            if attempt < retries - 1:
+                logging.warning(f"Request timed out. Retrying... (Attempt {attempt + 1}/{retries})")
+                continue
+            return None, "The request timed out. The AI server might be busy or your connection is slow."
+        except _openai.APIConnectionError:
+            if attempt < retries - 1:
+                logging.warning(f"Connection error. Retrying... (Attempt {attempt + 1}/{retries})")
+                await _asyncio.sleep(1)
+                continue
+            return None, "Could not connect to the AI server. Please check your internet connection."
+        except _openai.APIStatusError as e:
+            if e.status_code == 402:
+                return None, "AI Service Error: Out of credits. Please top up your provider account."
+            if attempt < retries - 1:
+                await _asyncio.sleep(1)
+                continue
+            return None, f"AI Service Error (HTTP {e.status_code}): {str(e)}"
+        except Exception as e:
+            last_error = str(e)
+            logging.exception(f"Unexpected async LLM API Error (Attempt {attempt + 1}): {str(e)}")
+            if attempt < retries - 1:
+                await _asyncio.sleep(0.5)
+                continue
+
+    return None, f"An unexpected error occurred after {retries} attempts: {last_error}"
+
+
 def build_draft_prompt(remedies, language):
     """Build a prompt for drafting a formal legal document based on remedies."""
     remedy_summary = json.dumps(remedies, indent=2)

--- a/core/app_utils.py
+++ b/core/app_utils.py
@@ -207,6 +207,26 @@ def extract_text_from_pdf(uploaded_pdf, enable_ocr: bool = False, ocr_languages:
     multi-modal OCR processor when OCR is enabled.
     """
     text = ""
+    parser_errors: List[str] = []
+
+    # Read input bytes early and perform lightweight safety checks
+    data = _read_input_bytes(uploaded_pdf)
+    if data is None:
+        raise ValueError("Unable to read uploaded file bytes.")
+
+    # File size protection
+    max_bytes = int(getattr(Config, 'MAX_FILE_SIZE_MB', 25)) * 1024 * 1024
+    if len(data) > max_bytes:
+        raise PDFProcessingError(f"PDF exceeds allowed size of {max_bytes} bytes.")
+
+    # Reject obvious malicious tokens (JavaScript, Launch actions, embedded files)
+    suspicious_signatures = [b'/JavaScript', b'/JS', b'/Launch', b'/EmbeddedFiles', b'/RichMedia', b'/OpenAction', b'/AA']
+    for sig in suspicious_signatures:
+        if sig in data:
+            parser_errors.append(f"Suspicious PDF token detected: {sig.decode('latin1')}")
+            # For safety, refuse to process PDFs containing active content
+            raise PDFProcessingError("PDF contains active or embedded content (JavaScript/Launch/EmbeddedFiles). Processing aborted.")
+
     if _is_image_input(uploaded_pdf):
         if not enable_ocr:
             raise ValueError("Image uploads require OCR. Re-run with OCR enabled.")
@@ -221,10 +241,19 @@ def extract_text_from_pdf(uploaded_pdf, enable_ocr: bool = False, ocr_languages:
             return _legacy_image_ocr_fallback(image_bytes, ocr_languages)
 
     try:
-        with pdfplumber.open(uploaded_pdf) as pdf:
+        import io as _io
+        with pdfplumber.open(_io.BytesIO(data)) as pdf:
             pages = []
-            for page in pdf.pages:
-                page_text = page.extract_text(x_tolerance=3, y_tolerance=3)
+            max_pages = int(getattr(Config, 'PDF_MAX_PAGES', 2000))
+            for i, page in enumerate(pdf.pages):
+                if i >= max_pages:
+                    parser_errors.append(f"PDF page limit reached: {max_pages}")
+                    break
+                try:
+                    page_text = page.extract_text(x_tolerance=3, y_tolerance=3)
+                except Exception as e:
+                    parser_errors.append(f"pdfplumber page extraction error page={i}: {e}")
+                    continue
                 if page_text:
                     pages.append(page_text)
             text = "\n".join(pages).strip()
@@ -233,27 +262,38 @@ def extract_text_from_pdf(uploaded_pdf, enable_ocr: bool = False, ocr_languages:
                 is_valid, quality = _validate_encoding_quality(text)
                 if is_valid:
                     return text
-    except Exception:
-        pass
+    except Exception as e:
+        parser_errors.append(f"pdfplumber open error: {e}")
 
     try:
-        if hasattr(uploaded_pdf, "seek"):
-            uploaded_pdf.seek(0)
-        reader = PdfReader(uploaded_pdf)
+        import io as _io
+        reader = PdfReader(_io.BytesIO(data), strict=False)
+        # Check for encryption
+        try:
+            if getattr(reader, 'is_encrypted', False):
+                # Try simple decryption
+                try:
+                    reader.decrypt("")
+                except Exception:
+                    parser_errors.append("Encrypted PDF cannot be processed.")
+                    raise PDFProcessingError("Encrypted PDF not supported.")
+        except Exception:
+            # continue; some pypdf versions may not expose is_encrypted
+            pass
+
         text = _extract_pages_pypdf(reader)
         if text:
-            # Validate encoding quality before returning
             is_valid, quality = _validate_encoding_quality(text)
             if is_valid:
                 return text
-    except Exception:
-        pass
+    except Exception as e:
+        parser_errors.append(f"pypdf read error: {e}")
 
     if not enable_ocr:
         if parser_errors:
             raise PDFProcessingError(
                 "Failed to extract text from PDF using pdfplumber and pypdf.",
-                parser_errors[-1],
+                "; ".join(parser_errors),
             )
         raise ValueError("No extractable text found. The PDF may be image-only or empty. Re-run with OCR enabled.")
 

--- a/core/ocr_engine.py
+++ b/core/ocr_engine.py
@@ -479,3 +479,75 @@ def extract_text_from_image(
     ocr = OCREngine()
     result = ocr.extract_text(image, languages, preprocess)
     return result.get('text', '')
+
+
+# Async non-blocking wrappers
+import asyncio
+
+
+async def extract_text_from_image_async(
+    image: np.ndarray,
+    languages: list = ['eng'],
+    preprocess: bool = True
+) -> str:
+    """Async wrapper for quick text extraction that offloads work to a thread.
+
+    This keeps async event-loops responsive when performing OCR using
+    blocking C-extensions like Tesseract and OpenCV.
+    """
+    ocr = OCREngine()
+    result = await asyncio.to_thread(ocr.extract_text, image, languages, preprocess)
+    return result.get('text', '')
+
+
+class AsyncOCREngine(OCREngine):
+    """Provides async equivalents for heavy OCR operations."""
+
+    async def extract_text_async(self, image: np.ndarray, languages: list = ['eng'], preprocess: bool = True, config: Optional[str] = None) -> Dict[str, Any]:
+        return await asyncio.to_thread(self.extract_text, image, languages, preprocess, config)
+
+    async def extract_text_with_layout_async(self, image: np.ndarray, languages: list = ['eng']) -> Dict[str, Any]:
+        return await asyncio.to_thread(self.extract_text_with_layout, image, languages)
+
+    async def extract_handwriting_async(self, image: np.ndarray, languages: list = ['eng']) -> Dict[str, Any]:
+        return await asyncio.to_thread(self.extract_handwriting, image, languages)
+
+    async def batch_process_images_async(self, image_paths: list, languages: list = ['eng'], callback=None) -> list:
+        """Process multiple images concurrently without blocking the event loop.
+
+        It uses a threadpool for CPU-bound image processing and OCR.
+        """
+        loop = asyncio.get_running_loop()
+        tasks = []
+        results = []
+
+        async def _process(path):
+            try:
+                image = await loop.run_in_executor(None, ImageProcessor.load_image, path)
+                if image is None:
+                    return {'file': path, 'success': False, 'error': 'Failed to load image'}
+                res = await asyncio.to_thread(self.extract_text, image, languages)
+                res['file'] = path
+                return res
+            except Exception as e:
+                return {'file': path, 'success': False, 'error': str(e)}
+
+        for path in image_paths:
+            tasks.append(asyncio.create_task(_process(path)))
+
+        for coro in asyncio.as_completed(tasks):
+            r = await coro
+            results.append(r)
+            if callback:
+                try:
+                    callback(len(results), len(image_paths), r)
+                except Exception:
+                    pass
+
+        return results
+
+    async def detect_language_async(self, image: np.ndarray) -> Dict[str, Any]:
+        return await asyncio.to_thread(self.detect_language, image)
+
+    async def improve_ocr_quality_async(self, image: np.ndarray, languages: list = ['eng'], iterations: int = 3) -> Dict[str, Any]:
+        return await asyncio.to_thread(self.improve_ocr_quality, image, languages, iterations)

--- a/core/rag_engine.py
+++ b/core/rag_engine.py
@@ -339,3 +339,95 @@ ANSWER IN {language} (include citations if possible):
         except Exception as e:
             LOGGER.error(f"Error querying RAG engine: {e}")
             return f"An error occurred while trying to answer your question: {str(e)}"
+
+    async def async_query(self, question: str, language: str, openai_client, chat_history: Optional[List[Dict[str, str]]] = None) -> str:
+        """Async version of `query` that uses an async LLM helper to avoid blocking the event loop."""
+        if not self.vector_store:
+            return "Please wait for the document to finish processing before asking questions."
+
+        try:
+            LOGGER.info(f"(async) Retrieving context for question: {question}")
+            retrieved = self.retrieve_with_scores(question, k=5)
+
+            if not retrieved:
+                LOGGER.info("Semantic search returned no results, trying keyword fallback")
+                keyword_results = self._keyword_fallback_search(question)
+                if keyword_results:
+                    context = "\n\n---\n\n".join(keyword_results)
+                    citations = []
+                    LOGGER.info(f"Keyword fallback found {len(keyword_results)} results")
+                else:
+                    return "I couldn't find relevant information in the document to answer your question."
+            else:
+                scores = [r.get("score", 0.0) for r in retrieved]
+                max_score = max(scores) if scores else 0.0
+                if max_score <= 1.0 and max_score >= -1.0:
+                    norm_scores = [max(0.0, min(1.0, (s + 1) / 2 if s < 0.0 else s)) for s in scores]
+                else:
+                    norm_scores = [max(0.0, min(1.0, float(s))) for s in scores]
+
+                confidence = max(norm_scores) if norm_scores else 0.0
+                threshold = float(getattr(Config, "RAG_CONFIDENCE_THRESHOLD", 0.2))
+                LOGGER.info(f"Retrieval confidence: {confidence:.3f} (threshold {threshold})")
+                if confidence < threshold:
+                    return "I cannot find sufficient evidence in the document to answer that question."
+
+                parts = []
+                citations = []
+                for r, s in zip(retrieved, norm_scores):
+                    meta = r.get("metadata", {})
+                    citation = f"[source:{meta.get('source_hash','unknown')}#chunk:{meta.get('chunk_index',0)}]"
+                    excerpt = meta.get("excerpt") or (r.get("content")[:240] + "...")
+                    parts.append(f"{excerpt}\n\nCitation: {citation} (score={s:.3f})")
+                    citations.append(citation)
+
+                context = "\n\n---\n\n".join(parts)
+
+            history_str = ""
+            if chat_history:
+                recent_history = chat_history[-6:]
+                history_str = "\n".join([f"{m['role'].upper()}: {m['content']}" for m in recent_history])
+
+            prompt = f"""
+You are LegalEase AI, an expert judicial researcher. 
+Your goal is to provide accurate, context-grounded answers to user questions about a specific legal document.
+
+STRICT GUIDELINES:
+1. Answer ONLY based on the provided CONTEXT. If the answer is not in the context, say "I cannot find the answer to this in the document."
+2. CITATIONS: Whenever possible, quote specific sentences or phrases from the document to support your answer.
+3. CONVERSATION: Use the RECENT CHAT HISTORY to understand follow-up questions (e.g., "What about the other person?").
+4. LANGUAGE: Provide your final answer ONLY in the {language} language.
+
+RECENT CHAT HISTORY:
+{history_str}
+
+CONEXT FROM DOCUMENT:
+{context}
+
+USER QUESTION:
+{question}
+
+ANSWER IN {language} (include citations if possible):
+"""
+
+            LOGGER.info("(async) Generating response from LLM...")
+            from core.app_utils import safe_llm_call_async
+            answer, error = await safe_llm_call_async(
+                client=openai_client,
+                model=Config.DEFAULT_MODEL,
+                messages=[
+                    {"role": "system", "content": f"You are a helpful legal researcher. Output only in {language}."},
+                    {"role": "user", "content": prompt}
+                ],
+                max_tokens=600,
+                temperature=0.1,
+            )
+
+            if error:
+                return f"AI Service Error: {error}"
+
+            return answer
+
+        except Exception as e:
+            LOGGER.error(f"Error querying RAG engine (async): {e}")
+            return f"An error occurred while trying to answer your question: {str(e)}"

--- a/db/otp_service.py
+++ b/db/otp_service.py
@@ -141,12 +141,21 @@ def get_pending_otp(db: Session, email: str) -> Optional[OTPVerification]:
     ).order_by(OTPVerification.created_at.desc()).first()
 
 
-def mark_otp_as_used(db: Session, otp_id: int) -> None:
-    """Mark an OTP as used"""
-    otp = db.query(OTPVerification).filter(OTPVerification.id == otp_id).first()
-    if otp:
-        otp.is_used = True
+def mark_otp_as_used(db: Session, otp_id: int) -> bool:
+    """Mark an OTP as used atomically.
+
+    Performs an UPDATE that only succeeds if the OTP is not already used.
+    Returns True when the row was updated (OTP marked used), False otherwise.
+    """
+    updated = db.query(OTPVerification).filter(
+        OTPVerification.id == otp_id,
+        OTPVerification.is_used == False,
+    ).update({"is_used": True})
+    if updated:
         db.commit()
+        return True
+    # nothing changed (already used or missing)
+    return False
 
 
 def cleanup_expired_otps(db: Session) -> int:

--- a/observability/instrumentation.py
+++ b/observability/instrumentation.py
@@ -30,6 +30,10 @@ try:
     from opentelemetry.sdk.resources import SERVICE_NAME, Resource
     from opentelemetry.sdk.metrics import MeterProvider
     from opentelemetry.instrumentation.flask import FlaskInstrumentor
+    try:
+        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+    except Exception:
+        FastAPIInstrumentor = None
     from opentelemetry.instrumentation.requests import RequestsInstrumentor
     from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
     from opentelemetry.instrumentation.redis import RedisInstrumentor
@@ -638,6 +642,27 @@ def initialize_observability():
     # Setup distributed tracing
     global tracer
     tracer = setup_jaeger_tracing()
+    # Auto-instrument common libraries when opentelemetry instrumentations are available
+    try:
+        if RequestsInstrumentor is not None:
+            RequestsInstrumentor().instrument()
+            log.info("requests_instrumented")
+    except Exception as e:
+        log.warning("requests_instrumentation_failed", error=str(e))
+
+    try:
+        if SQLAlchemyInstrumentor is not None:
+            SQLAlchemyInstrumentor().instrument()
+            log.info("sqlalchemy_instrumented")
+    except Exception as e:
+        log.warning("sqlalchemy_instrumentation_failed", error=str(e))
+
+    try:
+        if RedisInstrumentor is not None:
+            RedisInstrumentor().instrument()
+            log.info("redis_instrumented")
+    except Exception as e:
+        log.warning("redis_instrumentation_failed", error=str(e))
     
     # Start Prometheus metrics server
     metrics_port = int(os.getenv("PROMETHEUS_METRICS_PORT", "9090"))

--- a/observability/integration.py
+++ b/observability/integration.py
@@ -5,6 +5,7 @@ Add to app.py and other entry points
 
 import os
 import logging
+from datetime import datetime, timezone
 from observability.instrumentation import (
     initialize_observability,
     log,

--- a/tests/tmp_test_pdf.py
+++ b/tests/tmp_test_pdf.py
@@ -1,0 +1,12 @@
+from core import extract_text_from_pdf
+from core.app_utils import PDFProcessingError
+import io
+
+b = b"%PDF-1.4\n1 0 obj<< /Type /Catalog >>\n/JavaScript (alert)\n%%EOF"
+try:
+    extract_text_from_pdf(io.BytesIO(b), enable_ocr=False)
+    print('NO_ERROR')
+except PDFProcessingError as e:
+    print('RAISED_PDFPROCESSINGERROR', str(e))
+except Exception as e:
+    print('OTHER_ERROR', type(e), e)


### PR DESCRIPTION
Summary
This PR hardens authentication by preventing OTP replay, ensuring immediate JWT revocation takes effect, and adding a logout endpoint that revokes the presenting JWT. These changes close several race/replay vectors and make revocations effective immediately in memory as well as in the DB.

Changes
Add atomic OTP consume to prevent concurrent reuse of the same OTP.
Treat concurrent OTP consumption as a verification failure
Ensure JWT revocation updates in-memory revocation cache so token checks fail immediately.
Best-effort propagation to existing API-level revoke helpers so both [api] and legacy [auth] flows invalidate caches.

## ISSUE CLOSES #1049 
