### PR TITLE
Pin unversioned core dependencies in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,12 +10,12 @@ uvicorn>=0.22.0
 python-multipart>=0.0.6
 
 # --- Document Processing Pipeline ---
-pypdf
-pdfplumber
-pytesseract
-pdf2image
-Pillow
-fpdf2
+pypdf==6.12.1
+pdfplumber==0.11.9
+pytesseract==0.3.13
+pdf2image==1.17.0
+Pillow==12.2.0
+fpdf2==2.8.7
 python-magic>=0.4.27
 filetype>=1.2.0
 


### PR DESCRIPTION
## Summary

Pinned previously unversioned OCR/PDF processing dependencies in `requirements.txt` to improve reproducibility and deployment stability.

## Updated Dependencies

* pypdf==6.12.1
* pdfplumber==0.11.9
* pytesseract==0.3.13
* pdf2image==1.17.0
* Pillow==12.2.0
* fpdf2==2.8.7

## Validation

* Verified successful installation using:

  ```bash
  pip install -r requirements.txt
  ```
* Confirmed compatibility with Python 3.13.9.
* Re-ran OCR preprocessing tests successfully.

## Impact

Improves:

* reproducible builds
* deployment consistency
* CI/CD reliability
* OCR/PDF pipeline stability


Closes #1131