### PR TITLE
Remove unused imports from core runtime modules

### DIFF
--- a/core/image_processor.py
+++ b/core/image_processor.py
@@ -5,10 +5,8 @@ Handles image preprocessing, enhancement, and quality assessment
 
 import logging
 import numpy as np
-from PIL import Image, ImageEnhance, ImageFilter
 import cv2
-from typing import Tuple, Optional, Dict, Any
-from pathlib import Path
+from typing import Optional, Dict, Any
 
 logger = logging.getLogger(__name__)
 

--- a/core/ocr_engine.py
+++ b/core/ocr_engine.py
@@ -5,11 +5,8 @@ Handles text extraction from images and scanned documents using Tesseract
 
 import logging
 import pytesseract
-import cv2
 import numpy as np
-from typing import Dict, Any, Optional, Tuple
-from pathlib import Path
-import re
+from typing import Dict, Any, Optional
 from config import Config
 
 from core.image_processor import ImageProcessor

--- a/core/timezone_utils.py
+++ b/core/timezone_utils.py
@@ -4,7 +4,7 @@ Timezone utilities for consistent datetime display across the application.
 Provides helpers for timezone-aware datetime handling and user-local display.
 """
 
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone
 from typing import Optional, Union
 import pytz
 

--- a/pages/0_Home.py
+++ b/pages/0_Home.py
@@ -6,16 +6,16 @@ CHANGE: build_judgment_result_text now returns (plain_text, structured_dict).
         render_shareable_result_box accepts the tuple directly — no other changes needed.
 """
 
+import sys
+import os
+# Add parent directory to sys.path to resolve 'core' and other top-level modules
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 import streamlit as st
 import logging
 import routes
-import sys
-import os
 from config import Config
 from pages.ui_components import render_header, SESSION_KEYS
-
-# Add parent directory to sys.path to resolve 'core' module
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from core.app_utils import (
     get_client,
@@ -23,18 +23,13 @@ from core.app_utils import (
     extract_text_from_pdf,
     analyze_legal_citations,
     compress_text,
-    english_leakage_detected,
     output_language_mismatch_detected,
     build_prompt,
     build_retry_prompt,
     get_remedies_advice,
-    extract_appeal_info,
     get_localized_ui_text,
-    localize_yes_no,
     RETRO_STYLING,
     LANGUAGES,
-    parse_summary_bullets,
-    validate_pdf_metadata,
     build_judgment_result_text,
     render_shareable_result_box,
     safe_llm_call,
@@ -44,8 +39,6 @@ from core.app_utils import (
     parse_timeline,        
     build_timeline_prompt,
 )
-
-from core.multimodal_processor import MultiModalProcessor
 
 st.markdown(RETRO_STYLING, unsafe_allow_html=True)
 


### PR DESCRIPTION
## Summary

Removed unused imports from active runtime modules to improve readability, reduce lint warnings, and simplify dependency tracing.

## Validation

* Ran:

  ```bash
  flake8 . --select=F401
  ```
* Verified Streamlit page compilation:

  ```bash
  python -m py_compile pages/0_Home.py
  ```
* Confirmed OCR-related tests still pass successfully.

## Impact

Improves:

* code readability
* maintainability
* namespace cleanliness
* linting consistency

## Notes

Care was taken to avoid removing:

* dynamically referenced imports
* framework-injected imports
* side-effect imports
Closes #1132