### PR TITLE
[REFACTOR] Unify deadline reminder filtering 

### DIFF
--- a/db/crud/notifications.py
+++ b/db/crud/notifications.py
@@ -113,6 +113,73 @@ def update_notification_log_by_message_id(
     return log
 
 
+def reserve_notification(
+    db: Session,
+    deadline_id: int,
+    user_id: int,
+    channel: NotificationChannel,
+    recipient: str,
+    days_before: int,
+    message_preview: Optional[str] = None,
+) -> tuple[NotificationLog, bool]:
+    log, created = get_or_create_notification_log(
+        db=db,
+        deadline_id=deadline_id,
+        user_id=user_id,
+        channel=channel,
+        recipient=recipient,
+        days_before=days_before,
+    )
+
+    if created and message_preview is not None:
+        log.message_preview = message_preview
+        db.commit()
+        db.refresh(log)
+
+    return log, created
+
+
+def update_notification_result(
+    db: Session,
+    deadline_id: int,
+    user_id: int,
+    days_before: int,
+    channel: NotificationChannel,
+    status: NotificationStatus,
+    message_id: Optional[str] = None,
+    error_message: Optional[str] = None,
+    message_preview: Optional[str] = None,
+) -> NotificationLog:
+    updated = update_notification_log_by_keys(
+        db=db,
+        deadline_id=deadline_id,
+        days_before=days_before,
+        channel=channel,
+        status=status,
+        message_id=message_id,
+        error_message=error_message,
+        message_preview=message_preview,
+    )
+    if updated is not None:
+        return updated
+
+    log = log_notification(
+        db=db,
+        deadline_id=deadline_id,
+        user_id=user_id,
+        channel=channel,
+        recipient="",
+        days_before=days_before,
+        status=status,
+        message_id=message_id,
+        error_message=error_message,
+        message_preview=message_preview,
+    )
+    db.commit()
+    db.refresh(log)
+    return log
+
+
 def create_case_deadline(
     db: Session,
     user_id: int,

--- a/notifications/reminder_engine.py
+++ b/notifications/reminder_engine.py
@@ -3,11 +3,12 @@
 Pure helper functions and an orchestration planner that converts upcoming
 deadlines plus prefetched user preferences into actionable reminder candidates.
 """
-from dataclasses import dataclass
-from typing import Callable, Dict, Iterable, List
 import datetime as dt
+from typing import Callable, Dict, Iterable, List, Tuple
+
 import pytz
 
+from db.crud.notifications import get_prefs_by_user_ids
 from db.models.cases import CaseDeadline
 from db.models.notifications import UserPreference
 
@@ -49,29 +50,37 @@ def is_reminder_time_for_user(user_timezone: str, reminder_hour: int = 8) -> boo
         return user_now.hour == reminder_hour
 
 
-@dataclass(frozen=True)
-class ReminderCandidate:
-    deadline: CaseDeadline
-    days_left: int
-    timezone: str
-    notify_30_days: bool
-    notify_10_days: bool
-    notify_3_days: bool
-    notify_1_day: bool
-    notification_channel: object
-    user_preference: UserPreference
+ReminderDispatchCandidate = Tuple[CaseDeadline, int, UserPreference]
 
 
-def plan_eligible_reminders(
+def _ensure_utc_datetime(value: dt.datetime) -> dt.datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=dt.timezone.utc)
+    return value.astimezone(dt.timezone.utc)
+
+
+def _calculate_days_left(deadline: CaseDeadline, now_utc: dt.datetime) -> int:
+    deadline_date = deadline.deadline_date
+    if deadline_date is None:
+        return 0
+    if deadline_date.tzinfo is None:
+        deadline_date = deadline_date.replace(tzinfo=dt.timezone.utc)
+    else:
+        deadline_date = deadline_date.astimezone(dt.timezone.utc)
+    return max(0, (deadline_date.date() - now_utc.date()).days)
+
+
+def _build_reminder_dispatch_candidates(
     deadlines: Iterable[CaseDeadline],
     prefs_by_user_id: Dict[int, UserPreference],
-    reminder_time_checker: Callable[[str], bool] = is_reminder_time_for_user,
-) -> List[ReminderCandidate]:
-    """Plan reminder candidates from in-memory deadlines and preferences."""
-    candidates: List[ReminderCandidate] = []
+    now_utc: dt.datetime,
+    reminder_time_checker: Callable[[str], bool],
+) -> List[ReminderDispatchCandidate]:
+    candidates: List[ReminderDispatchCandidate] = []
+    normalized_now_utc = _ensure_utc_datetime(now_utc)
 
     for deadline in deadlines:
-        days_left = deadline.days_until_deadline()
+        days_left = _calculate_days_left(deadline, normalized_now_utc)
         if not should_process_threshold(days_left):
             continue
 
@@ -85,18 +94,63 @@ def plan_eligible_reminders(
         if not reminder_time_checker(user_pref.timezone):
             continue
 
-        candidates.append(
-            ReminderCandidate(
-                deadline=deadline,
-                days_left=days_left,
-                timezone=user_pref.timezone or "UTC",
-                notify_30_days=bool(user_pref.notify_30_days),
-                notify_10_days=bool(user_pref.notify_10_days),
-                notify_3_days=bool(user_pref.notify_3_days),
-                notify_1_day=bool(user_pref.notify_1_day),
-                notification_channel=user_pref.notification_channel,
-                user_preference=user_pref,
-            )
-        )
+        candidates.append((deadline, days_left, user_pref))
 
     return candidates
+
+
+def get_reminder_dispatch_candidates(
+    db,
+    days_before: int,
+    now_utc: dt.datetime,
+    reminder_time_checker: Callable[[str], bool] | None = None,
+) -> List[ReminderDispatchCandidate]:
+    """Build reminder candidates from the database and current UTC time."""
+    if reminder_time_checker is None:
+        reminder_time_checker = is_reminder_time_for_user
+
+    now_utc = _ensure_utc_datetime(now_utc)
+    target_utc = (now_utc + dt.timedelta(days=days_before)).replace(
+        hour=23,
+        minute=59,
+        second=59,
+        microsecond=999999,
+    )
+    deadlines = db.query(CaseDeadline).filter(
+        CaseDeadline.is_completed.is_(False),
+        CaseDeadline.deadline_date <= target_utc,
+        CaseDeadline.deadline_date > now_utc,
+    ).all()
+
+    prefs_by_user_id: Dict[int, UserPreference] = {}
+    if deadlines:
+        prefs = get_prefs_by_user_ids(db, {deadline.user_id for deadline in deadlines})
+        prefs_by_user_id = {pref.user_id: pref for pref in prefs}
+
+    return _build_reminder_dispatch_candidates(
+        deadlines,
+        prefs_by_user_id,
+        now_utc,
+        reminder_time_checker,
+    )
+
+
+def plan_eligible_reminders(
+    deadlines: Iterable[CaseDeadline],
+    prefs_by_user_id: Dict[int, UserPreference],
+    now_utc: dt.datetime | None = None,
+    reminder_time_checker: Callable[[str], bool] | None = None,
+) -> List[ReminderDispatchCandidate]:
+    """Plan reminder candidates from in-memory deadlines and preferences."""
+    if reminder_time_checker is None:
+        reminder_time_checker = is_reminder_time_for_user
+
+    if now_utc is None:
+        now_utc = dt.datetime.now(dt.timezone.utc)
+
+    return _build_reminder_dispatch_candidates(
+        deadlines,
+        prefs_by_user_id,
+        now_utc,
+        reminder_time_checker,
+    )

--- a/scheduler.py
+++ b/scheduler.py
@@ -92,15 +92,10 @@ from db import (
     engine,
     init_db,
     SessionLocal,
-    get_upcoming_deadlines,
-    get_prefs_by_user_ids,
-    UserPreference,
 )
 from db.crud.knowledge import process_due_knowledge_invalidations
 from notifications.reminder_engine import (
-    plan_eligible_reminders,
-    should_process_threshold,
-    is_notify_enabled,
+    get_reminder_dispatch_candidates,
     is_reminder_time_for_user,
 )
 from notification_service import NotificationService
@@ -231,9 +226,6 @@ def _send_deadline_reminders_safe(db, deadline, user_preference, days_left):
         return []
 
 
-# Reminder time logic moved to notifications.reminder_engine.build_reminder_jobs
-
-
 def check_and_send_reminders():
     """
     Hourly job: Check all upcoming deadlines and send reminders at 8 AM in each user's local timezone.
@@ -308,43 +300,19 @@ def check_and_send_reminders():
 
         db = SessionLocal()
         try:
-            # Check for deadlines in the next 31 days to ensure we catch the 30-day mark
-            upcoming_deadlines = get_upcoming_deadlines(db, days_before=31)
-            logger.info("scheduler_upcoming_deadlines_found", count=len(upcoming_deadlines))
+            candidates = get_reminder_dispatch_candidates(
+                db,
+                days_before=31,
+                now_utc=datetime.now(timezone.utc),
+                reminder_time_checker=is_reminder_time_for_user,
+            )
+            logger.info("scheduler_reminder_candidates_found", count=len(candidates))
 
             sent_count = 0
 
-            # Prefetch user preferences for eligible deadlines to avoid N+1 queries
-            eligible = []
-            for dl in upcoming_deadlines:
-                days_left = dl.days_until_deadline()
-                if should_process_threshold(days_left):
-                    eligible.append((dl, days_left))
-
-            user_ids = {d.user_id for d, _ in eligible}
-            prefs_by_user = {}
-            if user_ids:
-                prefs = db.query(UserPreference).filter(UserPreference.user_id.in_(list(user_ids))).all()
-                prefs_by_user = {p.user_id: p for p in prefs}
-
-            for deadline, days_left in eligible:
-                user_preference = prefs_by_user.get(deadline.user_id)
-                if not user_preference:
-                    logger.warning("scheduler_preferences_missing", user_id=deadline.user_id)
-                    continue
-
-                # Check if reminders should be sent based on preferences and time
-                if not is_notify_enabled(days_left, user_preference):
-                    logger.debug("scheduler_notifications_disabled", user_id=deadline.user_id, days_left=days_left)
-                    continue
-
-                if not is_reminder_time_for_user(user_preference.timezone):
-                    logger.debug("scheduler_waiting_for_reminder_window", user_id=deadline.user_id, user_timezone=user_preference.timezone)
-                    continue
-
+            for deadline, days_left, user_preference in candidates:
                 logger.info("scheduler_processing_deadline", case_id=deadline.case_id, days_left=days_left)
 
-                # Send reminders using the notification service
                 results = _send_deadline_reminders_safe(db, deadline, user_preference, days_left)
 
                 for res in results:
@@ -786,25 +754,20 @@ def check_reminders_sync(target_days: Optional[int] = None, db: Optional[object]
     
     try:
         logger.info("scheduler_sync_reminder_check_started", target_days=target_days)
-        upcoming_deadlines = get_upcoming_deadlines(db, days_before=31)
-        prefs = get_prefs_by_user_ids(db, {deadline.user_id for deadline in upcoming_deadlines})
-        prefs_by_user = {pref.user_id: pref for pref in prefs}
-        candidates = plan_eligible_reminders(
-            upcoming_deadlines,
-            prefs_by_user,
+        candidates = get_reminder_dispatch_candidates(
+            db,
+            days_before=31,
+            now_utc=datetime.now(timezone.utc),
             reminder_time_checker=is_reminder_time_for_user,
         )
         
         sent_count = 0
-        for candidate in candidates:
-            deadline = candidate.deadline
-            days_left = candidate.days_left
+        for deadline, days_left, user_preference in candidates:
 
             if target_days and days_left != target_days:
                 continue
 
-            # Send reminders
-            results = _send_deadline_reminders_safe(db, deadline, candidate.user_preference, days_left)
+            results = _send_deadline_reminders_safe(db, deadline, user_preference, days_left)
             sent_count += len([r for r in results if r.success])
 
         logger.info("scheduler_sync_reminder_check_completed", reminders_sent=sent_count)

--- a/tests/test_log_redaction.py
+++ b/tests/test_log_redaction.py
@@ -72,21 +72,11 @@ def test_scheduler_logs_mask_notification_recipients(capfd):
         days_until_deadline=lambda: 30,
     )
     fake_pref = SimpleNamespace(user_id=1, timezone="UTC")
-    fake_pref.notify_30_days = True
-    fake_pref.notify_10_days = True
-    fake_pref.notify_3_days = True
-    fake_pref.notify_1_day = True
 
-    fake_query = Mock()
-    fake_query.filter.return_value.all.return_value = [fake_pref]
-    fake_db = Mock()
-    fake_db.query.return_value = fake_query
-
-    with patch("scheduler.SessionLocal", return_value=fake_db), \
+    with patch("scheduler.SessionLocal", return_value=Mock()), \
             patch("scheduler.init_db", return_value=None), \
-         patch("scheduler.get_upcoming_deadlines", return_value=[fake_deadline]), \
-         patch("scheduler.notification_service.send_reminders") as mock_send_reminders, \
-         patch("scheduler.is_reminder_time_for_user", return_value=True):
+         patch("scheduler.get_reminder_dispatch_candidates", return_value=[(fake_deadline, 30, fake_pref)]), \
+         patch("scheduler.notification_service.send_reminders") as mock_send_reminders:
         mock_send_reminders.return_value = [
             NotificationResult(success=True, channel=NotificationChannel.SMS, recipient="+91-9876543210", message_id="sms_123", error=None),
             NotificationResult(success=True, channel=NotificationChannel.EMAIL, recipient="user@example.com", message_id="email_123", error=None),

--- a/tests/test_scheduler_comprehensive.py
+++ b/tests/test_scheduler_comprehensive.py
@@ -71,22 +71,22 @@ class TestSchedulerComprehensive:
                 phone_number=f"+91{days}00000000",
                 notification_channel=NotificationChannel.BOTH
             )
+            # Mock dependencies and underlying send functions (not the whole service)
+            with patch("scheduler.init_db"), \
+                 patch("scheduler.SessionLocal", return_value=test_db), \
+                 patch("scheduler.notification_service.send_reminders") as mock_send_reminders, \
+                 patch("scheduler.is_reminder_time_for_user", return_value=True):
 
-        # Mock dependencies and underlying send functions (not the whole service)
-        with patch("scheduler.SessionLocal", return_value=test_db), \
-             patch("scheduler.notification_service.send_reminders") as mock_send_reminders, \
-             patch("scheduler.is_reminder_time_for_user", return_value=True):
-            
-            # send_reminders returns a list of NotificationResult objects
-            mock_send_reminders.return_value = [
-                NotificationResult(success=True, channel=NotificationChannel.SMS, recipient="+91test", message_id="sms_123", error=None),
-                NotificationResult(success=True, channel=NotificationChannel.EMAIL, recipient="test@example.com", message_id="email_123", error=None),
-            ]
-            
-            check_and_send_reminders()
-            
-            # Verify it called send_reminders 4 times (once per threshold)
-            assert mock_send_reminders.call_count == 4
+                # send_reminders returns a list of NotificationResult objects
+                mock_send_reminders.return_value = [
+                    NotificationResult(success=True, channel=NotificationChannel.SMS, recipient="+91test", message_id="sms_123", error=None),
+                    NotificationResult(success=True, channel=NotificationChannel.EMAIL, recipient="test@example.com", message_id="email_123", error=None),
+                ]
+
+                check_and_send_reminders()
+
+                # Verify it called send_reminders 4 times (once per threshold)
+                assert mock_send_reminders.call_count == 4
 
     def test_check_and_send_reminders_continues_after_send_failure(self):
         """Test that one deadline failure does not stop later deadlines from being processed."""
@@ -138,9 +138,11 @@ class TestSchedulerComprehensive:
 
         with patch("scheduler.init_db"), \
              patch("scheduler.SessionLocal", return_value=fake_db), \
-             patch("scheduler.get_upcoming_deadlines", return_value=deadlines), \
+             patch("scheduler.get_reminder_dispatch_candidates", return_value=[
+                 (deadlines[0], 30, prefs[0]),
+                 (deadlines[1], 30, prefs[1]),
+             ]), \
              patch("scheduler.notification_service.send_reminders", side_effect=fake_send_reminders) as mock_send_reminders, \
-             patch("scheduler.is_reminder_time_for_user", return_value=True), \
              patch("scheduler.logger.error") as mock_error:
             check_and_send_reminders()
 


### PR DESCRIPTION
The reminder filtering now lives in one shared builder in reminder_engine.py, which returns dispatch candidates as deadline, days_left, user_preference tuples. scheduler.py now just asks for those candidates and runs a single dispatch loop in both the hourly and sync paths. I also added small CRUD compatibility shims in notifications.py so the existing notification service imports keep working.

The seeded scheduler test was updated to exercise the new path in test_scheduler_comprehensive.py, and the log-redaction test now patches the new candidate builder in test_log_redaction.py. Validation passed with a direct sanity check: the shared helper produced 4 candidates and the scheduler sent 4 reminders for the same seeded data.

closes #1157