### PR TITLE
Add OCR fallback handling for scanned PDFs

### DIFF
--- a/core/multimodal_processor.py
+++ b/core/multimodal_processor.py
@@ -134,15 +134,18 @@ class MultiModalProcessor:
             # Extract text from all pages
             text_pages = []
             total_pages = len(pdf_reader.pages)
+            ocr_used = False
+            confidences = []
             
             for page_num, page in enumerate(pdf_reader.pages):
                 page_text = page.extract_text()
                 if page_text and page_text.strip():
                     text_pages.append(page_text)
+                    confidences.append(100.0)
                 elif enable_ocr:
                     # Fallback to OCR for this page
                     logger.info(f"Page {page_num + 1} has no extractable text, using OCR")
-                    page_image = self._pdf_page_to_image(page)
+                    page_image = self._pdf_page_to_image(file_data, page_num)
                     if page_image is not None:
                         ocr_result = self.ocr_engine.extract_text(
                             page_image,
@@ -151,6 +154,11 @@ class MultiModalProcessor:
                         )
                         if ocr_result['success']:
                             text_pages.append(ocr_result['text'])
+                            ocr_used = True
+                            if 'confidence' in ocr_result and 'overall' in ocr_result['confidence']:
+                                confidences.append(ocr_result['confidence']['overall'])
+                            else:
+                                confidences.append(85.0)  # Default fallback confidence
             
             full_text = '\n\n'.join(text_pages)
             
@@ -159,14 +167,16 @@ class MultiModalProcessor:
                 logger.warning("PDF has little extractable text, treating as scanned")
                 return self._process_scanned_pdf(file_data, languages, aggressive_ocr)
             
+            avg_confidence = float(np.mean(confidences)) if confidences else 100.0
+            
             return {
                 'text': full_text,
                 'success': True,
                 'file_type': 'pdf',
                 'pages_processed': len(text_pages),
                 'total_pages': total_pages,
-                'ocr_used': False,
-                'confidence': 100.0  # High confidence for extractable text
+                'ocr_used': ocr_used,
+                'confidence': avg_confidence
             }
             
         except Exception as e:
@@ -323,22 +333,41 @@ class MultiModalProcessor:
                 'file_type': 'image'
             }
     
-    def _pdf_page_to_image(self, page) -> Optional[np.ndarray]:
-        """Convert PDF page to image for OCR
+    def _pdf_page_to_image(
+        self,
+        file_data: Union[bytes, str, Path],
+        page_num: int
+    ) -> Optional[np.ndarray]:
+        """Convert a specific PDF page to an image for OCR.
         
         Args:
-            page: PDF page object
+            file_data: PDF file data or path
+            page_num: Zero-indexed page number
             
         Returns:
             Image as numpy array or None
         """
         try:
             from pdf2image import convert_from_bytes
-            # This is a simplified approach
-            # In production, you'd use pdf2image directly on the PDF
-            logger.warning("Direct page-to-image conversion not implemented")
+            
+            if isinstance(file_data, (str, Path)):
+                with open(file_data, 'rb') as f:
+                    pdf_bytes = f.read()
+            else:
+                pdf_bytes = file_data
+                
+            images = convert_from_bytes(
+                pdf_bytes,
+                first_page=page_num + 1,
+                last_page=page_num + 1,
+                dpi=300
+            )
+            
+            if images:
+                return np.array(images[0])
             return None
-        except ImportError:
+        except Exception as e:
+            logger.error(f"Failed to convert PDF page {page_num + 1} to image: {e}")
             return None
     
     def extract_handwriting(


### PR DESCRIPTION
## Summary

Implemented OCR fallback handling for scanned/image-only PDFs inside the multimodal document processor.

## Changes Made

* added scanned-page OCR fallback flow
* integrated page-level PDF rendering using `pdf2image`
* rendered only target pages during fallback
* preserved existing extraction flow for normal PDFs
* merged OCR output into downstream processing pipeline

## Validation

* verified module compilation successfully
* tested scanned PDFs without embedded text
* confirmed OCR fallback triggers correctly
* validated downstream OCR text integration
* ensured no runtime/import regressions

## Impact

Improves:

* scanned PDF handling
* OCR extraction reliability
* multimodal document processing accuracy
* processing consistency for image-only legal documents

Closes #1187
