### PR TITLE
solved

### DIFF
--- a/app.py
+++ b/app.py
@@ -43,6 +43,8 @@ import routes
 from observability.integration import initialize_observability_for_environment
 
 # Initialize database
+from database import init_db, SessionLocal, db_session, CaseRecord
+from db.models import DocumentType
 from config import Config
 Config.validate_runtime_security()
 init_db()
@@ -855,7 +857,6 @@ def main():
                         db = None
                         try:
                             from analytics_engine import AnalyticsAggregator
-                            from database import CaseRecord
                             
                             db = SessionLocal()
                             summary = AnalyticsAggregator.get_dashboard_summary(db)

--- a/reproduce_bug.py
+++ b/reproduce_bug.py
@@ -1,0 +1,8 @@
+
+try:
+    import app
+    print("app.py imported successfully")
+except NameError as e:
+    print(f"Caught expected NameError: {e}")
+except Exception as e:
+    print(f"Caught unexpected error: {type(e).__name__}: {e}")


### PR DESCRIPTION
## Description
This Pull Request resolves critical application crashes caused by missing module and entity imports in `app.py`. Previously, operations such as saving a document or initializing the application would throw a `NameError` and halt execution.

**Changes included in this PR:**
* Added the missing import for `DocumentType` to fix the crash during `upload_case_document` execution.
* Restored necessary database imports (such as `init_db` and `SessionLocal`) at the top of the file to ensure the database initializes correctly on startup and analytics render properly.

## Related Issues
* Fixes #1387 


## Steps to Test
1. Start the Streamlit application (`streamlit run app.py`).
2. Verify that the app loads successfully without a `NameError` on startup.
3. Upload a document, generate a summary, and successfully save it to a case. 
4. Check that the terminal no longer throws `NameError: name 'DocumentType' is not defined`.

## Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have tested these changes locally and verified they resolve the stated issues.
- [x] There are no new warnings or errors generated by these changes.

## Additional Context
I am submitting this PR as an active contributor for **Nexus Spring of Code (NSoC '26)** and **GirlScript Summer of Code (GSSoC '26)**. Thank you for reviewing! 🚀