### PR TITLE
fix: remove .jwt_secret file fallback for anonymization secret (#1240)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ env/
 # Environment variables
 .env
 
+# Secret files — must never be committed
+.jwt_secret
+*.secret
+
 # Streamlit secrets
 .streamlit/secrets.toml
 

--- a/services/case_anonymization.py
+++ b/services/case_anonymization.py
@@ -6,7 +6,6 @@ import hashlib
 import logging
 import hmac
 import os
-from pathlib import Path
 from typing import Any, Dict, Optional
 
 from sqlalchemy.orm import Session
@@ -26,15 +25,36 @@ _MIN_SECRET_LENGTH = 32
 logger = logging.getLogger(__name__)
 
 
-def _get_case_anonymization_secret(override: Optional[str] = None) -> str:
-    """
-    Resolve the anonymization secret.
+def _check_secret_entropy(secret: str, source: str) -> None:
+    """Raise if the secret has dangerously low entropy.
 
-    Rules:
-    - If `override` is provided it may only be used in test mode (`Config.TESTING` True).
-    - Prefer `CASE_ANONYMIZATION_SECRET` environment/secret.
-    - Fallback to project `.jwt_secret` file only in non-production environments.
-    - Enforce minimum secret length.
+    A secret composed entirely of one repeated character (e.g. ``"a" * 40``)
+    passes a length check but provides near-zero security.  This guard catches
+    the most common weak-secret patterns used in development that could
+    accidentally reach a non-production environment connected to real data.
+    """
+    if len(set(secret)) < 8:
+        raise ValueError(
+            f"Anonymization secret from {source} has insufficient entropy "
+            f"(fewer than 8 distinct characters). Use a randomly generated secret."
+        )
+
+
+def _get_case_anonymization_secret(override: Optional[str] = None) -> str:
+    """Resolve the anonymization secret.
+
+    Resolution order
+    ----------------
+    1. Test-time ``override`` — only accepted when ``Config.TESTING`` is True.
+    2. ``CASE_ANONYMIZATION_SECRET`` environment variable / Streamlit secret.
+
+    The previous fallback to the ``.jwt_secret`` file has been removed.
+    Reading a secret from a file that may be committed to version control
+    creates a systematic risk: any developer or CI runner with repo read
+    access can forge valid anonymized IDs and, if the same file is used as
+    the JWT secret, forge valid authentication tokens.
+
+    Set ``CASE_ANONYMIZATION_SECRET`` in your environment or secrets manager.
     """
     # Test-time override support
     if override is not None:
@@ -45,33 +65,30 @@ def _get_case_anonymization_secret(override: Optional[str] = None) -> str:
             raise ValueError(f"Anonymization secret must be at least {_MIN_SECRET_LENGTH} characters")
         return secret
 
-    # Primary source: environment / streamlit secrets
+    # Primary (and only) source: environment / streamlit secrets
     secret = os.getenv("CASE_ANONYMIZATION_SECRET", "").strip()
+    if not secret:
+        # Also check via Config._get_val so Streamlit secrets are honoured
+        try:
+            from config import _get_val as _cfg_get
+            secret = str(_cfg_get("CASE_ANONYMIZATION_SECRET", "") or "").strip()
+        except Exception:
+            pass
+
     if secret:
         if len(secret) < _MIN_SECRET_LENGTH:
-            raise ValueError(f"Anonymization secret from environment must be at least {_MIN_SECRET_LENGTH} characters")
+            raise ValueError(
+                f"Anonymization secret from environment must be at least "
+                f"{_MIN_SECRET_LENGTH} characters"
+            )
+        _check_secret_entropy(secret, "environment")
         return secret
 
-    # Secondary fallback: .jwt_secret file (only allowed in non-production)
-    jwt_secret_path = Path(__file__).resolve().parents[1] / ".jwt_secret"
-    if not jwt_secret_path.exists():
-        jwt_secret_path = Path(__file__).resolve().parents[2] / ".jwt_secret"
-
-    if jwt_secret_path.exists():
-        try:
-            file_secret = jwt_secret_path.read_text(encoding="utf-8").strip()
-        except (OSError, UnicodeDecodeError):
-            logger.exception("Failed to read anonymization secret from %s", jwt_secret_path)
-        else:
-            if file_secret:
-                if Config.is_production():
-                    # Disallow falling back to file in production for security
-                    raise RuntimeError("Anonymization secret must be provided via CASE_ANONYMIZATION_SECRET in production")
-                if len(file_secret) < _MIN_SECRET_LENGTH:
-                    raise ValueError(f"Anonymization secret from file must be at least {_MIN_SECRET_LENGTH} characters")
-                return file_secret
-
-    raise RuntimeError("CASE_ANONYMIZATION_SECRET is not configured.")
+    raise RuntimeError(
+        "CASE_ANONYMIZATION_SECRET is not configured. "
+        "Set this environment variable to a randomly generated secret of at least "
+        f"{_MIN_SECRET_LENGTH} characters."
+    )
 
 
 def _generate_anonymized_case_id(case_id: int, created_at: Any, secret_override: Optional[str] = None) -> str:

--- a/tests/test_case_anonymization.py
+++ b/tests/test_case_anonymization.py
@@ -5,22 +5,30 @@ import services.case_anonymization as ca
 
 import pytest
 
+# Use secrets with sufficient entropy (8+ distinct chars) to pass the new
+# entropy check introduced by the #1240 fix.
+_SECRET_A = "aB3dEf7hIj0kLmNoPqRsTuVwXyZ12345678"
+_SECRET_B = "bC4eFg8iJk1lMnOpQrStUvWxYz23456789a"
+_SECRET_S = "sT5uGh9jKl2mNoOpQrStUvWxYz34567890b"
+_SECRET_F = "fG6vHi0kLm3nOpQrStUvWxYz45678901cd"
+_SECRET_Z = "zA7wBj1lMn4oOpQrStUvWxYz56789012ef"
+
 
 def test_anonymized_id_changes_with_secret(monkeypatch):
     # Import inside test so monkeypatch can affect env var used during module import.
-    monkeypatch.setenv("CASE_ANONYMIZATION_SECRET", "a" * 40)
+    monkeypatch.setenv("CASE_ANONYMIZATION_SECRET", _SECRET_A)
 
     created_at = datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
     anon_a = ca._generate_anonymized_case_id(case_id=123, created_at=created_at)
 
-    monkeypatch.setenv("CASE_ANONYMIZATION_SECRET", "b" * 40)
+    monkeypatch.setenv("CASE_ANONYMIZATION_SECRET", _SECRET_B)
     anon_b = ca._generate_anonymized_case_id(case_id=123, created_at=created_at)
 
     assert anon_a != anon_b
 
 
 def test_anonymized_id_deterministic_with_same_secret(monkeypatch):
-    monkeypatch.setenv("CASE_ANONYMIZATION_SECRET", "s" * 40)
+    monkeypatch.setenv("CASE_ANONYMIZATION_SECRET", _SECRET_S)
 
     created_at = datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
     anon_1 = ca._generate_anonymized_case_id(case_id=123, created_at=created_at)
@@ -30,7 +38,7 @@ def test_anonymized_id_deterministic_with_same_secret(monkeypatch):
 
 
 def test_anonymized_id_format(monkeypatch):
-    monkeypatch.setenv("CASE_ANONYMIZATION_SECRET", "f" * 40)
+    monkeypatch.setenv("CASE_ANONYMIZATION_SECRET", _SECRET_F)
 
     created_at = datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
     anon = ca._generate_anonymized_case_id(case_id=123, created_at=created_at)
@@ -40,7 +48,7 @@ def test_anonymized_id_format(monkeypatch):
 
 
 def test_different_inputs_produce_different_ids(monkeypatch):
-    monkeypatch.setenv("CASE_ANONYMIZATION_SECRET", "z" * 40)
+    monkeypatch.setenv("CASE_ANONYMIZATION_SECRET", _SECRET_Z)
     from datetime import datetime, timezone
 
     dt1 = datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
@@ -59,7 +67,7 @@ def test_secret_override_allowed_only_in_testing():
     prev = Config.TESTING
     try:
         Config.TESTING = True
-        # should not raise when testing
+        # should not raise when testing — override bypasses entropy check
         dt = __import__("datetime").datetime.utcnow()
         val = ca._generate_anonymized_case_id(1, dt, secret_override=("o" * 40))
         assert isinstance(val, str) and len(val) == 12
@@ -74,4 +82,3 @@ def test_secret_override_allowed_only_in_testing():
             ca._generate_anonymized_case_id(1, dt, secret_override=("o" * 40))
     finally:
         Config.TESTING = prev
-

--- a/tests/test_jwt_secret_file_fallback.py
+++ b/tests/test_jwt_secret_file_fallback.py
@@ -1,0 +1,167 @@
+"""Tests for the JWT secret file-fallback removal fix (#1240).
+
+Verifies that:
+- The .jwt_secret file is no longer used as a fallback secret source.
+- CASE_ANONYMIZATION_SECRET env var is the only accepted source.
+- Weak / low-entropy secrets are rejected.
+- The .jwt_secret path is listed in .gitignore.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-value-12345")
+os.environ.setdefault("APP_ALLOWED_HOSTS", "localhost")
+
+# Stub optional heavy deps
+for _mod in ("streamlit", "pytesseract", "pdf2image"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+import pytest
+import services.case_anonymization as ca
+
+
+# ---------------------------------------------------------------------------
+# File fallback is gone
+# ---------------------------------------------------------------------------
+
+def test_jwt_secret_file_not_used_as_fallback(tmp_path, monkeypatch):
+    """.jwt_secret file must NOT be read even when it exists and env var is unset."""
+    # Ensure env var is absent
+    monkeypatch.delenv("CASE_ANONYMIZATION_SECRET", raising=False)
+
+    # Create a valid .jwt_secret file in a temp dir
+    secret_file = tmp_path / ".jwt_secret"
+    secret_file.write_text("a" * 40, encoding="utf-8")
+
+    # Patch _get_val so Streamlit path also returns nothing
+    with patch("services.case_anonymization._get_val" if hasattr(ca, "_get_val") else "config._get_val",
+               return_value="", create=True):
+        with pytest.raises(RuntimeError, match="CASE_ANONYMIZATION_SECRET is not configured"):
+            ca._get_case_anonymization_secret()
+
+
+def test_env_var_is_accepted(monkeypatch):
+    """CASE_ANONYMIZATION_SECRET env var must be accepted."""
+    import secrets as _secrets
+    strong = _secrets.token_hex(32)
+    monkeypatch.setenv("CASE_ANONYMIZATION_SECRET", strong)
+    secret = ca._get_case_anonymization_secret()
+    assert secret == strong
+
+
+def test_missing_env_var_raises(monkeypatch):
+    """Missing env var must raise RuntimeError with a clear message."""
+    monkeypatch.delenv("CASE_ANONYMIZATION_SECRET", raising=False)
+    with patch("config._get_val", return_value=""):
+        with pytest.raises(RuntimeError, match="CASE_ANONYMIZATION_SECRET is not configured"):
+            ca._get_case_anonymization_secret()
+
+
+# ---------------------------------------------------------------------------
+# Entropy check
+# ---------------------------------------------------------------------------
+
+def test_low_entropy_secret_rejected(monkeypatch):
+    """A secret made of one repeated character must be rejected."""
+    monkeypatch.setenv("CASE_ANONYMIZATION_SECRET", "a" * 40)
+    with pytest.raises(ValueError, match="insufficient entropy"):
+        ca._get_case_anonymization_secret()
+
+
+def test_high_entropy_secret_accepted(monkeypatch):
+    """A randomly generated secret with sufficient entropy must be accepted."""
+    import secrets as _secrets
+    strong = _secrets.token_hex(32)  # 64 hex chars, high entropy
+    monkeypatch.setenv("CASE_ANONYMIZATION_SECRET", strong)
+    result = ca._get_case_anonymization_secret()
+    assert result == strong
+
+
+def test_secret_too_short_rejected(monkeypatch):
+    """A secret shorter than _MIN_SECRET_LENGTH must be rejected."""
+    monkeypatch.setenv("CASE_ANONYMIZATION_SECRET", "short")
+    with pytest.raises(ValueError, match="at least"):
+        ca._get_case_anonymization_secret()
+
+
+# ---------------------------------------------------------------------------
+# Test-mode override still works
+# ---------------------------------------------------------------------------
+
+def test_override_allowed_in_testing(monkeypatch):
+    """Secret override must work when Config.TESTING is True."""
+    from config import Config
+    prev = Config.TESTING
+    try:
+        Config.TESTING = True
+        result = ca._get_case_anonymization_secret(override="t" * 40)
+        # "t" * 40 has only 1 distinct char — but override skips entropy check
+        assert result == "t" * 40
+    finally:
+        Config.TESTING = prev
+
+
+def test_override_blocked_outside_testing(monkeypatch):
+    """Secret override must be blocked when Config.TESTING is False."""
+    from config import Config
+    prev = Config.TESTING
+    try:
+        Config.TESTING = False
+        with pytest.raises(RuntimeError, match="testing mode"):
+            ca._get_case_anonymization_secret(override="t" * 40)
+    finally:
+        Config.TESTING = prev
+
+
+# ---------------------------------------------------------------------------
+# .gitignore contains .jwt_secret
+# ---------------------------------------------------------------------------
+
+def test_jwt_secret_in_gitignore():
+    """.jwt_secret must be listed in .gitignore to prevent accidental commits."""
+    gitignore = Path(__file__).resolve().parents[1] / ".gitignore"
+    assert gitignore.exists(), ".gitignore not found at project root"
+    content = gitignore.read_text(encoding="utf-8")
+    assert ".jwt_secret" in content, (
+        ".jwt_secret is not listed in .gitignore — it could be accidentally committed "
+        "and expose secrets to anyone with repo read access."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Existing anonymization tests still pass (smoke check)
+# ---------------------------------------------------------------------------
+
+def test_generate_anonymized_case_id_deterministic(monkeypatch):
+    """ID generation must remain deterministic with the same env secret."""
+    import secrets as _secrets
+    strong = _secrets.token_hex(32)
+    monkeypatch.setenv("CASE_ANONYMIZATION_SECRET", strong)
+    from datetime import datetime, timezone
+    dt = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    id1 = ca._generate_anonymized_case_id(case_id=1, created_at=dt)
+    id2 = ca._generate_anonymized_case_id(case_id=1, created_at=dt)
+    assert id1 == id2
+    assert len(id1) == 12
+
+
+def test_generate_anonymized_case_id_changes_with_secret(monkeypatch):
+    """Different secrets must produce different IDs."""
+    import secrets as _secrets
+    from datetime import datetime, timezone
+    dt = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    monkeypatch.setenv("CASE_ANONYMIZATION_SECRET", _secrets.token_hex(32))
+    id_a = ca._generate_anonymized_case_id(case_id=1, created_at=dt)
+
+    monkeypatch.setenv("CASE_ANONYMIZATION_SECRET", _secrets.token_hex(32))
+    id_b = ca._generate_anonymized_case_id(case_id=1, created_at=dt)
+
+    assert id_a != id_b


### PR DESCRIPTION
The _get_case_anonymization_secret() function fell back to reading the .jwt_secret file from the project root in non-production environments. This file was not in .gitignore, meaning it could be committed and expose the secret to anyone with repo read access. A developer running against real data with a known secret could forge valid anonymized IDs.

Changes:
- services/case_anonymization.py: remove .jwt_secret file fallback entirely. CASE_ANONYMIZATION_SECRET env var is now the only accepted source. Add _check_secret_entropy() to reject low-entropy secrets (fewer than 8 distinct characters) that pass length checks but provide near-zero security.
- .gitignore: add .jwt_secret and *.secret patterns so these files can never be accidentally committed.
- tests/test_jwt_secret_file_fallback.py: 11 new tests covering file fallback removal, entropy check, env var acceptance, missing config error, test-mode override, and .gitignore verification.
- tests/test_case_anonymization.py: update existing tests to use high-entropy secrets that pass the new entropy check.
fixes #1240 