### PR TITLE
import NameError for db_session and SessionLocal in pp.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,6 +41,8 @@ from auth import init_auth_session, require_auth, get_current_user_id, get_curre
 from case_manager import get_user_cases_summary, upload_case_document, create_new_case, get_case_detail
 import routes
 from observability.integration import initialize_observability_for_environment
+from database import init_db, db_session, SessionLocal
+from analytics_engine import AnalyticsAggregator
 
 # Initialize database
 from config import Config


### PR DESCRIPTION
## Description
This Pull Request fixes a critical bug where the "Analytics Preview" section was permanently non-functional. 

Previously, when the application attempted to render the analytics dashboard, it threw a `NameError` under the hood because `db_session` and `SessionLocal` were not imported into `app.py`. The UI silently swallowed this crash and permanently displayed a fallback "module not ready" message.

**Changes included in this PR:**
* Added the missing imports for `db_session` and `SessionLocal` from the database module at the top of `app.py`.
* Verified that the `AnalyticsAggregator` functions have the correct database session context required to query and render the statistical metrics properly.

## Related Issues
* Fixes #1390

## Steps to Test
1. Start the Streamlit application locally (`streamlit run app.py`).
2. Scroll down to the "Case Tracking & Regional Trends" section.
3. Click the "View Stats" or "View Analytics" button.
4. Verify that the application successfully queries the database and renders the actual analytics dashboard instead of displaying the fallback error message.
5. Check the terminal to ensure no `NameError` is logged under the hood.

## Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have tested these changes locally and verified they resolve the stated issue.
- [x] There are no new warnings or errors generated by these changes.

## Additional Context
I am submitting this PR as an active contributor for **Nexus Spring of Code (NSoC '26)** and **GirlScript Summer of Code (GSSoC '26)**. Thank you for the assignment and review! 🚀