### PR TITLE
feat:Delivery tracking & event callbacks

### DIFF
--- a/api/routes/notifications.py
+++ b/api/routes/notifications.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from urllib.parse import parse_qsl
+from typing import Any
 
 
 
@@ -29,6 +30,49 @@ except ImportError:  # pragma: no cover - optional dependency
 
 router = APIRouter(prefix="/api/v1/webhooks", tags=["notifications"])
 logger = structlog.get_logger(__name__)
+
+
+def _parse_twilio_webhook_payload(raw_body: str) -> dict[str, str]:
+    return dict(parse_qsl(raw_body, keep_blank_values=True))
+
+
+def _parse_sendgrid_webhook_payload(raw_body: str) -> list[dict[str, Any]]:
+    try:
+        events = json.loads(raw_body or "[]")
+    except json.JSONDecodeError as exc:
+        raise StructuredAPIError(status_code=status.HTTP_400_BAD_REQUEST, error_code="SENDGRID_WEBHOOK_INVALID_JSON", message="Invalid SendGrid webhook payload") from exc
+
+    if isinstance(events, dict):
+        events = [events]
+
+    if not isinstance(events, list):
+        raise StructuredAPIError(status_code=status.HTTP_400_BAD_REQUEST, error_code="SENDGRID_WEBHOOK_INVALID_JSON", message="Invalid SendGrid webhook payload")
+
+    normalized_events: list[dict[str, Any]] = []
+    for event in events:
+        if not isinstance(event, dict):
+            raise StructuredAPIError(status_code=status.HTTP_400_BAD_REQUEST, error_code="SENDGRID_WEBHOOK_INVALID_JSON", message="Invalid SendGrid webhook payload")
+        normalized_events.append(event)
+
+    return normalized_events
+
+
+def _twilio_status_to_notification_status(message_status: str) -> NotificationStatus | None:
+    normalized = (message_status or "").lower()
+    if normalized == "delivered":
+        return NotificationStatus.DELIVERED
+    if normalized in {"failed", "undelivered", "canceled", "cancelled"}:
+        return NotificationStatus.FAILED
+    return None
+
+
+def _sendgrid_event_to_notification_status(event_type: str) -> NotificationStatus | None:
+    normalized = (event_type or "").lower()
+    if normalized == "delivered":
+        return NotificationStatus.DELIVERED
+    if normalized in {"bounce", "dropped", "deferred", "blocked", "spamreport", "invalid"}:
+        return NotificationStatus.FAILED
+    return None
 
 
 def _message_id_candidates(message_id: str | None) -> list[str]:
@@ -107,7 +151,7 @@ def _update_delivery_status(db: Session, message_id: str | None, status_value: N
 @router.post("/twilio")
 async def twilio_delivery_webhook(request: Request, db: Session = Depends(get_db_rls_optional)) -> dict:
     raw_body = (await request.body()).decode("utf-8")
-    params = dict(parse_qsl(raw_body, keep_blank_values=True))
+    params = _parse_twilio_webhook_payload(raw_body)
 
     if not _verify_twilio_signature(request, params):
         raise StructuredAPIError(status_code=status.HTTP_401_UNAUTHORIZED, error_code="TWILIO_SIGNATURE_INVALID", message="Invalid Twilio signature")
@@ -116,9 +160,10 @@ async def twilio_delivery_webhook(request: Request, db: Session = Depends(get_db
     message_status = (params.get("MessageStatus") or params.get("SmsStatus") or "").lower()
     error_code = params.get("ErrorCode")
 
-    if message_status == "delivered":
+    normalized_status = _twilio_status_to_notification_status(message_status)
+    if normalized_status == NotificationStatus.DELIVERED:
         updated = _update_delivery_status(db, message_sid, NotificationStatus.DELIVERED)
-    elif message_status in {"failed", "undelivered", "canceled", "cancelled"}:
+    elif normalized_status == NotificationStatus.FAILED:
         updated = _update_delivery_status(db, message_sid, NotificationStatus.FAILED, error_message=f"Twilio status: {message_status}{f' ({error_code})' if error_code else ''}")
     else:
         updated = None
@@ -134,13 +179,7 @@ async def sendgrid_delivery_webhook(request: Request, db: Session = Depends(get_
     if not _verify_sendgrid_signature(request, raw_body):
         raise StructuredAPIError(status_code=status.HTTP_401_UNAUTHORIZED, error_code="SENDGRID_SIGNATURE_INVALID", message="Invalid SendGrid signature")
 
-    try:
-        events = json.loads(raw_body or "[]")
-    except json.JSONDecodeError as exc:
-        raise StructuredAPIError(status_code=status.HTTP_400_BAD_REQUEST, error_code="SENDGRID_WEBHOOK_INVALID_JSON", message="Invalid SendGrid webhook payload") from exc
-
-    if isinstance(events, dict):
-        events = [events]
+    events = _parse_sendgrid_webhook_payload(raw_body)
 
     processed = 0
     updated = 0
@@ -148,9 +187,10 @@ async def sendgrid_delivery_webhook(request: Request, db: Session = Depends(get_
         processed += 1
         event_type = str(event.get("event", "")).lower()
         message_id = event.get("sg_message_id") or event.get("message_id") or event.get("smtp-id")
-        if event_type == "delivered":
+        normalized_status = _sendgrid_event_to_notification_status(event_type)
+        if normalized_status == NotificationStatus.DELIVERED:
             result = _update_delivery_status(db, message_id, NotificationStatus.DELIVERED)
-        elif event_type in {"bounce", "dropped", "deferred", "blocked", "spamreport", "invalid"}:
+        elif normalized_status == NotificationStatus.FAILED:
             reason = event.get("reason") or event.get("response") or event_type
             result = _update_delivery_status(db, message_id, NotificationStatus.FAILED, error_message=str(reason))
         else:

--- a/notifications_ui.py
+++ b/notifications_ui.py
@@ -190,6 +190,9 @@ def page_notification_preferences():
                 st.error(f"❌ Error saving preferences: {str(e)}")
                 logger.error(f"Error saving preferences: {str(e)}")
 
+    finally:
+        db.close()
+
     # --- Template Builder ---
     st.divider()
     st.subheader("✉️ Reminder Template Builder")
@@ -435,17 +438,22 @@ def page_notification_history():
             return
 
         # Summary statistics
+        delivered_notifications = [n for n in notifications if n.status.value == "delivered"]
+        failed_notifications = [n for n in notifications if n.status.value == "failed"]
+        sms_notifications = [n for n in notifications if n.channel.value == "sms"]
+        email_notifications = [n for n in notifications if n.channel.value == "email"]
+
         col1, col2, col3, col4 = st.columns(4)
 
         total = len(notifications)
-        sent = len([n for n in notifications if n.status.value == "sent"])
-        failed = len([n for n in notifications if n.status.value == "failed"])
-        sms_count = len([n for n in notifications if n.channel.value == "sms"])
+        delivered = len(delivered_notifications)
+        failed = len(failed_notifications)
+        sms_count = len(sms_notifications)
 
         with col1:
             st.metric("Total Notifications", total)
         with col2:
-            st.metric("Successfully Sent", sent)
+            st.metric("Delivered", delivered)
         with col3:
             st.metric("Failed", failed)
         with col4:
@@ -453,17 +461,33 @@ def page_notification_history():
 
         st.divider()
 
+        channel_rows = []
+        for channel_name, channel_notifications in (("SMS", sms_notifications), ("Email", email_notifications)):
+            channel_rows.append({
+                "Channel": channel_name,
+                "Delivered": len([n for n in channel_notifications if n.status.value == "delivered"]),
+                "Failed": len([n for n in channel_notifications if n.status.value == "failed"]),
+                "Pending": len([n for n in channel_notifications if n.status.value == "pending"]),
+                "Sent": len([n for n in channel_notifications if n.status.value == "sent"]),
+            })
+
+        st.subheader("Delivery by Channel")
+        st.dataframe(pd.DataFrame(channel_rows), use_container_width=True, hide_index=True)
+
         # Notification table
         st.subheader("Recent Notifications")
 
         for notif in notifications[:20]:  # Show last 20
             status_emoji = {
-                "sent": "✅",
+                "delivered": "✅",
                 "failed": "❌",
+                "sent": "✅",
                 "pending": "⏳",
                 "bounced": "↩️",
                 "opened": "👁️",
             }.get(notif.status.value, "❓")
+            status_label = notif.status.value.replace("_", " ").title()
+            timeline_value = notif.delivered_at or notif.failed_at or notif.sent_at or notif.created_at
 
             with st.container(border=True):
                 col1, col2, col3, col4 = st.columns([2, 2, 2, 1])
@@ -472,19 +496,24 @@ def page_notification_history():
                     case_title = notif.deadline.case_title if notif.deadline else "Deleted Case/Deadline"
                     st.text(f"Case: {case_title}")
                     st.caption(notif.recipient)
+                    if notif.message_id:
+                        st.caption(f"Message ID: {notif.message_id}")
 
                 with col2:
                     st.text(f"Channel: {notif.channel.value.upper()}")
                     st.caption(f"Reminder: {notif.days_before} day(s)")
+                    st.caption(f"Status: {status_label}")
 
                 with col3:
-                    st.text(f"Sent: {notif.created_at.strftime('%d %b %Y %H:%M')}")
+                    st.text(f"Created: {notif.created_at.strftime('%d %b %Y %H:%M')}")
+                    if timeline_value:
+                        st.caption(f"Updated: {timeline_value.strftime('%d %b %Y %H:%M')}")
+                    if notif.error_message:
+                        st.caption(f"Error: {notif.error_message}")
 
                 with col4:
                     st.markdown(f"### {status_emoji}")
 
-                if notif.error_message:
-                    st.error(f"Error: {notif.error_message}")
 
     finally:
         db.close()

--- a/tests/test_notification_webhooks.py
+++ b/tests/test_notification_webhooks.py
@@ -11,6 +11,7 @@ from sqlalchemy.pool import StaticPool
 from twilio.request_validator import RequestValidator
 
 import api.main as api_main
+from api.routes import notifications as notification_routes
 from config import Config
 from database import get_db
 from db.base import Base
@@ -169,3 +170,31 @@ def test_sendgrid_webhook_marks_notification_failed(client, test_db):
     assert refreshed.failed_at is not None
     assert "Bounced Address" in (refreshed.error_message or "")
     assert refreshed.delivered_at is None
+
+
+def test_twilio_payload_parser_maps_delivery_status_and_message_id_candidates():
+    payload = "MessageSid=SM123&MessageStatus=delivered&ErrorCode=&SmsStatus=delivered"
+
+    params = notification_routes._parse_twilio_webhook_payload(payload)
+
+    assert params["MessageSid"] == "SM123"
+    assert notification_routes._twilio_status_to_notification_status(params["MessageStatus"]) == NotificationStatus.DELIVERED
+    candidates = notification_routes._message_id_candidates("<SM123.test@example.com>")
+    assert candidates[0] == "SM123.test@example.com"
+    assert "SM123" in candidates
+
+
+def test_sendgrid_payload_parser_normalizes_single_event_and_failure_status():
+    payload = json.dumps(
+        {
+            "event": "bounce",
+            "sg_message_id": "msg-123.filterdrecv-1.0",
+            "reason": "Mailbox unavailable",
+        }
+    )
+
+    events = notification_routes._parse_sendgrid_webhook_payload(payload)
+
+    assert len(events) == 1
+    assert events[0]["sg_message_id"] == "msg-123.filterdrecv-1.0"
+    assert notification_routes._sendgrid_event_to_notification_status(events[0]["event"]) == NotificationStatus.FAILED


### PR DESCRIPTION
The notification webhook flow is now easier to test and the history UI shows delivery outcome instead of only the send attempt. I added parser/classifier helpers in notifications.py so Twilio and SendGrid payloads can be unit-tested directly, and I expanded notifications_ui.py to show delivered/failed counts by channel plus per-item status, message ID, and timestamps.

I also added direct payload-parser tests in test_notification_webhooks.py and test_notification_webhooks.py. Validation passed with `py_compile` on the touched files; a full `pytest` run in this environment is blocked earlier by a missing `sqlalchemy` install during test collection.


closes #1341