### PR TITLE
feat:Advanced message templating with variables

### DIFF
--- a/database.py
+++ b/database.py
@@ -56,6 +56,8 @@ from db.crud.notifications import (
     has_notification_been_sent,
     log_notification,
     get_notification_history,
+    get_notification_template_for_user,
+    create_or_update_notification_template,
 )
 from db.case_service import save_case_note_draft, publish_case_note, get_case_note_history
 from db.otp_service import revoke_token, is_token_revoked, cleanup_expired_revoked_tokens
@@ -104,6 +106,8 @@ __all__ = [
     "has_notification_been_sent",
     "log_notification",
     "get_notification_history",
+    "get_notification_template_for_user",
+    "create_or_update_notification_template",
     "create_or_update_user_preference",
     "create_user",
     "get_user_by_email",

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -20,6 +20,8 @@ from .crud.notifications import (
     get_prefs_by_user_ids,
     has_notification_been_sent,
     log_notification,
+    get_notification_template_for_user,
+    create_or_update_notification_template,
     update_notification_log_by_message_id,
     get_notification_history,
 )
@@ -55,6 +57,8 @@ __all__ = [
     "get_prefs_by_user_ids",
     "has_notification_been_sent",
     "log_notification",
+    "get_notification_template_for_user",
+    "create_or_update_notification_template",
     "update_notification_log_by_message_id",
     "get_notification_history",
     "submit_user_feedback",

--- a/db/crud/notifications.py
+++ b/db/crud/notifications.py
@@ -310,6 +310,51 @@ def get_notification_history(db: Session, user_id: int, limit: int = 50) -> List
     ).order_by(NotificationLog.created_at.desc()).limit(limit).all()
 
 
-def get_notification_template_for_user(db: Session, user_id: int):
-    return db.query(NotificationTemplate).filter(NotificationTemplate.user_id == user_id).first()
+def get_notification_template_for_user(
+    db: Session,
+    user_id: int,
+    channel: Optional[NotificationChannel] = None,
+    language: Optional[str] = None,
+):
+    template = db.query(NotificationTemplate).filter(NotificationTemplate.user_id == user_id).first()
+    if not template:
+        return None
+    if channel is None and language is None:
+        return template
+    return template
+
+
+def create_or_update_notification_template(
+    db: Session,
+    user_id: int,
+    sms_template: Optional[str] = None,
+    email_subject_template: Optional[str] = None,
+    email_html_template: Optional[str] = None,
+    channel: Optional[NotificationChannel] = None,
+    language: Optional[str] = None,
+):
+    template = db.query(NotificationTemplate).filter(NotificationTemplate.user_id == user_id).first()
+    if not template:
+        template = NotificationTemplate(user_id=user_id)
+        db.add(template)
+
+    if channel is None and language is None:
+        if sms_template is not None:
+            template.sms_template = sms_template
+        if email_subject_template is not None:
+            template.email_subject_template = email_subject_template
+        if email_html_template is not None:
+            template.email_html_template = email_html_template
+    else:
+        template.set_template_variant(
+            channel=channel,
+            language=language,
+            sms_template=sms_template,
+            email_subject_template=email_subject_template,
+            email_html_template=email_html_template,
+        )
+
+    db.commit()
+    db.refresh(template)
+    return template
 

--- a/db/models/notifications.py
+++ b/db/models/notifications.py
@@ -76,11 +76,73 @@ class NotificationTemplate(Base):
 
     id = Column(Integer, primary_key=True)
     user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), unique=True, nullable=False, index=True)
+    template_variants = Column(JSON, nullable=True)
     sms_template = Column(Text, nullable=True)
     email_subject_template = Column(String(255), nullable=True)
     email_html_template = Column(Text, nullable=True)
     created_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), nullable=False)
     updated_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), onupdate=lambda: dt.datetime.now(dt.timezone.utc))
+
+    def _template_scope_key(self, value):
+        if value is None:
+            return "default"
+        if hasattr(value, "value"):
+            value = value.value
+        text = str(value).strip().lower()
+        return text or "default"
+
+    def resolve_templates(self, channel=None, language=None):
+        variants = self.template_variants if isinstance(self.template_variants, dict) else {}
+        channel_key = self._template_scope_key(channel)
+        language_key = self._template_scope_key(language)
+
+        candidate_maps = []
+        for candidate_channel, candidate_language in (
+            (channel_key, language_key),
+            (channel_key, "default"),
+            ("default", language_key),
+            ("default", "default"),
+        ):
+            channel_bucket = variants.get(candidate_channel)
+            if isinstance(channel_bucket, dict):
+                candidate = channel_bucket.get(candidate_language)
+                if isinstance(candidate, dict):
+                    candidate_maps.append(candidate)
+
+        selected = candidate_maps[0] if candidate_maps else {}
+        return {
+            "sms_template": selected.get("sms_template") or self.sms_template,
+            "email_subject_template": selected.get("email_subject_template") or self.email_subject_template,
+            "email_html_template": selected.get("email_html_template") or self.email_html_template,
+        }
+
+    def set_template_variant(
+        self,
+        channel=None,
+        language=None,
+        sms_template=None,
+        email_subject_template=None,
+        email_html_template=None,
+    ):
+        variants = self.template_variants if isinstance(self.template_variants, dict) else {}
+        variants = dict(variants)
+
+        channel_key = self._template_scope_key(channel)
+        language_key = self._template_scope_key(language)
+
+        channel_bucket = dict(variants.get(channel_key, {}))
+        variant = dict(channel_bucket.get(language_key, {}))
+
+        if sms_template is not None:
+            variant["sms_template"] = sms_template
+        if email_subject_template is not None:
+            variant["email_subject_template"] = email_subject_template
+        if email_html_template is not None:
+            variant["email_html_template"] = email_html_template
+
+        channel_bucket[language_key] = variant
+        variants[channel_key] = channel_bucket
+        self.template_variants = variants
 
 
 class NotificationLog(Base):

--- a/notification_service.py
+++ b/notification_service.py
@@ -6,6 +6,7 @@ Handles delivery tracking and retry logic.
 import logging
 import structlog
 import os
+import re
 from datetime import datetime, timezone
 from typing import Optional, List, Tuple
 from dataclasses import dataclass
@@ -87,6 +88,98 @@ def _is_debug_or_testing_mode() -> bool:
     return Config.DEBUG or Config.TESTING
 
 logger = structlog.get_logger(__name__)
+
+NOTIFICATION_TEMPLATE_ALLOWED_VARS = {
+    "case_title",
+    "case_number",
+    "deadline_date",
+    "days_before",
+    "days_left",
+    "court",
+    "deadline_type",
+    "deadline_description",
+    "first_action",
+    "link",
+    "channel",
+    "language",
+}
+
+
+def _template_language_key(language: Optional[str]) -> str:
+    text = str(language or "en").strip().lower()
+    return text or "en"
+
+
+def _derive_first_action(deadline: CaseDeadline) -> str:
+    description = (getattr(deadline, "description", "") or "").strip()
+    if description:
+        first_sentence = re.split(r"(?<=[.!?])\s+", description, maxsplit=1)[0].strip()
+        if len(first_sentence) > 140:
+            first_sentence = first_sentence[:137].rstrip() + "..."
+        return first_sentence
+
+    deadline_type = str(getattr(deadline, "deadline_type", "") or "").strip().lower()
+    suggestions = {
+        "appeal": "Draft and file the appeal",
+        "filing": "Prepare and submit the filing",
+        "submission": "Gather the required documents and submit them",
+        "response": "Prepare the response and verify deadlines",
+        "hearing": "Review the hearing strategy and supporting documents",
+        "other": "Review the deadline details and plan the next step",
+    }
+    return suggestions.get(deadline_type, "Review the deadline details and plan the next step")
+
+
+def _build_notification_template_values(
+    deadline: CaseDeadline,
+    days_left: int,
+    channel: NotificationChannel,
+    language: Optional[str] = None,
+) -> dict[str, str]:
+    case = getattr(deadline, "case", None)
+    deadline_date = getattr(deadline, "deadline_date", None)
+    deadline_date_text = deadline_date.strftime("%d %b %Y") if hasattr(deadline_date, "strftime") else ""
+    case_number = getattr(case, "case_number", "") if case is not None else ""
+    case_title = getattr(deadline, "case_title", "") or getattr(case, "title", "") or ""
+    court = getattr(case, "jurisdiction", "") if case is not None else ""
+    template_language = _template_language_key(language)
+
+    return {
+        "case_title": str(case_title),
+        "case_number": str(case_number),
+        "deadline_date": deadline_date_text,
+        "days_before": str(days_left),
+        "days_left": str(days_left),
+        "court": str(court),
+        "deadline_type": str(getattr(deadline, "deadline_type", "") or ""),
+        "deadline_description": str(getattr(deadline, "description", "") or ""),
+        "first_action": _derive_first_action(deadline),
+        "link": f"https://legalassist.ai/cases/{getattr(deadline, 'case_id', '')}",
+        "channel": channel.value if hasattr(channel, "value") else str(channel),
+        "language": template_language,
+    }
+
+
+def _render_notification_template(template: str, values: dict[str, str]) -> str:
+    return render_template(
+        template,
+        values,
+        allowed=NOTIFICATION_TEMPLATE_ALLOWED_VARS,
+        missing_as_empty=True,
+    )
+
+
+def _resolve_notification_template_values(
+    db: Session,
+    deadline: CaseDeadline,
+    days_left: int,
+    channel: NotificationChannel,
+    language: Optional[str] = None,
+) -> dict[str, Optional[str]]:
+    template = get_notification_template_for_user(db, deadline.user_id, channel=channel, language=language)
+    if not template:
+        return {"sms_template": None, "email_subject_template": None, "email_html_template": None}
+    return template.resolve_templates(channel=channel, language=language)
 
 
 @dataclass
@@ -703,6 +796,7 @@ class NotificationService:
         deadline: CaseDeadline,
         user_preference: UserPreference,
         days_left: int,
+        language: Optional[str] = None,
     ) -> NotificationResult:
         """Send SMS reminder for a deadline"""
         
@@ -715,22 +809,16 @@ class NotificationService:
                 error="No phone number configured",
             )
 
+        template_language = _template_language_key(language)
+
         # Try per-user template first
         message = None
         try:
-            tmpl = get_notification_template_for_user(db, deadline.user_id)
-            if tmpl and tmpl.sms_template:
-                values = {
-                    "case_title": getattr(deadline, 'case_title', ''),
-                    "case_number": getattr(deadline, "case_id", ""),
-                    "deadline_date": deadline.deadline_date.strftime("%d %b %Y") if deadline.deadline_date else "",
-                    "days_left": days_left,
-                    "court": "",
-                    "deadline_type": deadline.deadline_type,
-                    "deadline_description": deadline.description or "",
-                    "link": f"https://legalassist.ai/cases/{deadline.case_id}",
-                }
-                message = render_template(tmpl.sms_template, values)
+            tmpl = _resolve_notification_template_values(db, deadline, days_left, NotificationChannel.SMS, template_language)
+            sms_template = tmpl.get("sms_template") if isinstance(tmpl, dict) else None
+            if sms_template:
+                values = _build_notification_template_values(deadline, days_left, NotificationChannel.SMS, template_language)
+                message = _render_notification_template(sms_template, values)
         except TemplateValidationError as e:
             logger.warning("User SMS template invalid, falling back to default: %s", str(e))
         except Exception:
@@ -787,28 +875,21 @@ class NotificationService:
         deadline: CaseDeadline,
         user_preference: UserPreference,
         days_left: int,
+        language: Optional[str] = None,
     ) -> NotificationResult:
         """Send email reminder for a deadline"""
+        template_language = _template_language_key(language)
         # Try per-user template first
         subject = None
         html_content = None
         try:
-            tmpl = get_notification_template_for_user(db, deadline.user_id)
-            if tmpl and (tmpl.email_html_template or tmpl.email_subject_template):
-                values = {
-                    "case_title": getattr(deadline, 'case_title', ''),
-                    "case_number": getattr(deadline, "case_id", ""),
-                    "deadline_date": deadline.deadline_date.strftime("%d %B %Y") if deadline.deadline_date else "",
-                    "days_left": days_left,
-                    "court": "",
-                    "deadline_type": deadline.deadline_type,
-                    "deadline_description": deadline.description or "",
-                    "link": f"https://legalassist.ai/cases/{deadline.case_id}",
-                }
-                if tmpl.email_subject_template:
-                    subject = render_template(tmpl.email_subject_template, values)
-                if tmpl.email_html_template:
-                    html_content = render_template(tmpl.email_html_template, values)
+            tmpl = _resolve_notification_template_values(db, deadline, days_left, NotificationChannel.EMAIL, template_language)
+            if tmpl and (tmpl.get("email_html_template") or tmpl.get("email_subject_template")):
+                values = _build_notification_template_values(deadline, days_left, NotificationChannel.EMAIL, template_language)
+                if tmpl.get("email_subject_template"):
+                    subject = _render_notification_template(tmpl["email_subject_template"], values)
+                if tmpl.get("email_html_template"):
+                    html_content = _render_notification_template(tmpl["email_html_template"], values)
         except TemplateValidationError as e:
             logger.warning("User email template invalid, falling back to default: %s", str(e))
         except Exception:
@@ -892,6 +973,7 @@ class NotificationService:
         deadline: CaseDeadline,
         user_preference: UserPreference,
         days_left: Optional[int] = None,
+        language: Optional[str] = None,
     ) -> List[NotificationResult]:
         """
         Send appropriate reminders based on days until deadline and user preferences.
@@ -918,14 +1000,16 @@ class NotificationService:
             channels = [user_preference.notification_channel]
 
 
+        notification_language = language or getattr(user_preference, "language", None) or "en"
+
         for channel in channels:
             # Check if reminder was already sent for this specific threshold and channel
             if not has_notification_been_sent(db, deadline.id, days_left, channel):
                 if channel == NotificationChannel.SMS:
-                    result = self.send_sms_reminder(db, deadline, user_preference, days_left)
+                    result = self.send_sms_reminder(db, deadline, user_preference, days_left, notification_language)
                     results.append(result)
                 elif channel == NotificationChannel.EMAIL:
-                    result = self.send_email_reminder(db, deadline, user_preference, days_left)
+                    result = self.send_email_reminder(db, deadline, user_preference, days_left, notification_language)
                     results.append(result)
             else:
                 logger.debug("Notification already sent", 

--- a/notifications_ui.py
+++ b/notifications_ui.py
@@ -212,6 +212,17 @@ def page_notification_preferences():
         sms_input = st.text_area("SMS Template", value=sms_val, height=120, key="sms_template_input")
         subj_input = st.text_input("Email Subject Template", value=subj_val, key="email_subject_input")
         html_input = st.text_area("Email HTML Template", value=html_val, height=220, key="email_html_input")
+        channel_scope = st.selectbox(
+            "Template Scope",
+            ["Default", "SMS", "Email"],
+            index=0,
+            help="Choose Default to keep the legacy single-template behavior, or target a specific channel.",
+        )
+        template_language = st.text_input(
+            "Template Language (optional)",
+            value="",
+            help="Use a locale tag like en or hi. Leave blank to store the default template.",
+        ).strip()
 
         col1, col2 = st.columns(2)
         with col1:
@@ -264,13 +275,33 @@ def page_notification_preferences():
             if st.button("Save Templates", use_container_width=True):
                 try:
                     from database import create_or_update_notification_template
-                    create_or_update_notification_template(
-                        db=db,
-                        user_id=int(user_id),
-                        sms_template=sms_input,
-                        email_subject_template=subj_input,
-                        email_html_template=html_input,
-                    )
+                    from db.models.notifications import NotificationChannel
+
+                    selected_channel = None
+                    if channel_scope == "SMS":
+                        selected_channel = NotificationChannel.SMS
+                    elif channel_scope == "Email":
+                        selected_channel = NotificationChannel.EMAIL
+
+                    selected_language = template_language or None
+                    if selected_channel is None and selected_language is None:
+                        create_or_update_notification_template(
+                            db=db,
+                            user_id=int(user_id),
+                            sms_template=sms_input,
+                            email_subject_template=subj_input,
+                            email_html_template=html_input,
+                        )
+                    else:
+                        create_or_update_notification_template(
+                            db=db,
+                            user_id=int(user_id),
+                            sms_template=sms_input,
+                            email_subject_template=subj_input,
+                            email_html_template=html_input,
+                            channel=selected_channel,
+                            language=selected_language,
+                        )
                     st.success("✅ Templates saved")
                 except Exception as e:
                     st.error(f"Failed to save templates: {str(e)}")

--- a/tests/test_notification_service_extended.py
+++ b/tests/test_notification_service_extended.py
@@ -13,11 +13,12 @@ from database import (
     NotificationChannel,
     create_case_deadline,
     create_or_update_user_preference,
+    create_or_update_notification_template,
     Case,
     CaseStatus,
     User,
 )
-from notification_service import NotificationService, SMSClient, EmailClient
+from notification_service import NotificationService, SMSClient, EmailClient, _render_notification_template
 
 @pytest.fixture(scope="function")
 def test_db():
@@ -109,3 +110,51 @@ class TestNotificationServiceExtended:
             # This is hard to test after imports have already happened in the module
             # But we can at least check if the logic in the module would handle it
             pass
+
+    def test_missing_template_variables_render_safely(self):
+        template = "Your deadline for {case_title} is in {days_before} days. Suggested action: {first_action}."
+        rendered = _render_notification_template(
+            template,
+            {
+                "case_title": "State vs Smith",
+                "days_before": 7,
+                "days_left": 7,
+                "link": "https://legalassist.ai/cases/1",
+            },
+        )
+
+        assert "State vs Smith" in rendered
+        assert "7 days" in rendered
+        assert "Suggested action:" in rendered
+
+    def test_notification_template_variant_resolution(self, test_db):
+        user = User(email="templating@example.com")
+        test_db.add(user)
+        test_db.commit()
+        test_db.refresh(user)
+
+        create_or_update_notification_template(
+            db=test_db,
+            user_id=user.id,
+            sms_template="Default {case_title}",
+            email_subject_template="Default subject {case_title}",
+            email_html_template="<p>Default {case_title}</p>",
+        )
+
+        create_or_update_notification_template(
+            db=test_db,
+            user_id=user.id,
+            sms_template="Hindi SMS {case_title} {first_action}",
+            channel=NotificationChannel.SMS,
+            language="hi",
+        )
+
+        template = test_db.query(__import__("database").NotificationTemplate).filter(
+            __import__("database").NotificationTemplate.user_id == user.id
+        ).one()
+
+        resolved_hi = template.resolve_templates(channel=NotificationChannel.SMS, language="hi")
+        resolved_default = template.resolve_templates(channel=NotificationChannel.EMAIL, language="en")
+
+        assert resolved_hi["sms_template"] == "Hindi SMS {case_title} {first_action}"
+        assert resolved_default["sms_template"] == "Default {case_title}"


### PR DESCRIPTION
Advanced templating is wired in now. The notification service builds a richer variable context from the case/deadline record, renders through a whitelist-backed helper that includes `first_action`, `days_before`, and `days_left`, and falls back safely when a variable is missing instead of crashing. The template store now supports per-channel/per-language variants via `template_variants` on notifications.py, with save/resolve helpers in notifications.py and notifications.py. The reminder flow uses that resolver in notification_service.py and notification_service.py, notification_service.py, notification_service.py.

I also exposed the variant controls in the template editor UI at notifications_ui.py and notifications_ui.py, so you can save either the legacy default template or a channel/language-specific variant. Tests now cover safe missing-variable rendering and variant resolution in test_notification_service_extended.py and test_notification_service_extended.py.

Validation passed with `py_compile` on the touched files. I did not run the full pytest suite here because this environment still fails test collection on the project’s SQLAlchemy dependency.


closes #1342