### PR TITLE
feat:Appeal/deadline “smart next action” engine

### DIFF
--- a/api/routes/deadlines.py
+++ b/api/routes/deadlines.py
@@ -14,6 +14,7 @@ from datetime import datetime, timedelta, timezone
 
 from database import Case, CaseDeadline
 from api.dependencies import get_db_rls
+from core.deadline_engine import get_deadline_first_action
 
 router = APIRouter(prefix="/api/v1/deadlines", tags=["deadlines"])
 logger = structlog.get_logger(__name__)
@@ -281,10 +282,10 @@ async def create_deadline(
             """
             INSERT INTO case_deadlines (
                 user_id, case_id, case_title, deadline_date, deadline_type,
-                description, created_at, updated_at, is_completed, status
+                first_action, description, created_at, updated_at, is_completed, status
             ) VALUES (
                 :user_id, :case_id, :case_title, :deadline_date, :deadline_type,
-                :description, :created_at, :updated_at, :is_completed, :status
+                :first_action, :description, :created_at, :updated_at, :is_completed, :status
             )
             """
         ),
@@ -294,6 +295,7 @@ async def create_deadline(
             "case_title": case["title"] or case["case_number"],
             "deadline_date": normalized_due_date,
             "deadline_type": priority or "manual",
+            "first_action": get_deadline_first_action(priority or "manual"),
             "description": description or title,
             "created_at": now,
             "updated_at": now,

--- a/case_manager.py
+++ b/case_manager.py
@@ -56,6 +56,7 @@ from database import (
     get_attachments_for_case,
     save_case_note_draft,
 )
+from core.deadline_engine import get_deadline_first_action
 from db.case_service import get_case_note, publish_case_note, get_case_note_history
 from services.timeline_service import timeline_service as _timeline_service
 from services.deadlines_auto_creator import (
@@ -867,6 +868,7 @@ def add_manual_deadline(
             case_title=case_title,
             deadline_date=deadline_date,
             deadline_type=deadline_type,
+            first_action=get_deadline_first_action(deadline_type),
             description=description,
         )
         db.add(deadline)

--- a/core/deadline_engine.py
+++ b/core/deadline_engine.py
@@ -147,3 +147,24 @@ def calculate_deadline(
 
 
 __all__ = ["calculate_deadline"]
+
+
+_DEADLINE_TYPE_FIRST_ACTIONS: Dict[str, str] = {
+    "appeal": "File appeal memo",
+    "filing": "Gather filing documents",
+    "submission": "Prepare and submit the required filing",
+    "response": "Draft the response and review supporting records",
+    "hearing": "Consult counsel and prepare the hearing bundle",
+    "order": "Review the order and confirm the next step",
+    "other": "Review the deadline details and plan the next step",
+    "manual": "Review the deadline details and plan the next step",
+}
+
+
+def get_deadline_first_action(deadline_type: Optional[str]) -> str:
+    """Return a short deterministic next-action suggestion for a deadline type."""
+    normalized = str(deadline_type or "other").strip().lower()
+    return _DEADLINE_TYPE_FIRST_ACTIONS.get(normalized, "Review the deadline details and plan the next step")
+
+
+__all__.append("get_deadline_first_action")

--- a/db/crud/notifications.py
+++ b/db/crud/notifications.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session
 from db.models.notifications import NotificationLog, NotificationStatus, NotificationChannel, NotificationTemplate, UserPreference
 from db.models.cases import CaseDeadline, Case
 from sqlalchemy.exc import IntegrityError
+from core.deadline_engine import get_deadline_first_action
 
 
 def get_or_create_notification_log(
@@ -223,6 +224,7 @@ def create_case_deadline(
         case_title=case_title,
         deadline_date=deadline_date,
         deadline_type=deadline_type,
+        first_action=get_deadline_first_action(deadline_type),
         description=description,
     )
     db.add(deadline)

--- a/db/models/cases.py
+++ b/db/models/cases.py
@@ -51,6 +51,7 @@ class CaseDeadline(Base):
     case_title = Column(String(255), nullable=False)
     deadline_date = Column(DateTime(timezone=True), nullable=False, index=True)
     deadline_type = Column(String(255), nullable=False)
+    first_action = Column(String(255), nullable=True)
     description = Column(Text, nullable=True)
     created_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), nullable=False)
     updated_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), onupdate=lambda: dt.datetime.now(dt.timezone.utc))

--- a/notification_service.py
+++ b/notification_service.py
@@ -71,6 +71,7 @@ from db.crud.notifications import (
 )
 from db.crud.audit import record_immutable_audit_event
 from core.template_renderer import render_template, validate_template, TemplateValidationError
+from core.deadline_engine import get_deadline_first_action
 from core.log_redaction import mask_recipient, sanitize_log_text
 from services.timeline_service import timeline_service as case_timeline_service
 
@@ -112,23 +113,11 @@ def _template_language_key(language: Optional[str]) -> str:
 
 
 def _derive_first_action(deadline: CaseDeadline) -> str:
-    description = (getattr(deadline, "description", "") or "").strip()
-    if description:
-        first_sentence = re.split(r"(?<=[.!?])\s+", description, maxsplit=1)[0].strip()
-        if len(first_sentence) > 140:
-            first_sentence = first_sentence[:137].rstrip() + "..."
-        return first_sentence
+    stored_action = (getattr(deadline, "first_action", None) or "").strip()
+    if stored_action:
+        return stored_action
 
-    deadline_type = str(getattr(deadline, "deadline_type", "") or "").strip().lower()
-    suggestions = {
-        "appeal": "Draft and file the appeal",
-        "filing": "Prepare and submit the filing",
-        "submission": "Gather the required documents and submit them",
-        "response": "Prepare the response and verify deadlines",
-        "hearing": "Review the hearing strategy and supporting documents",
-        "other": "Review the deadline details and plan the next step",
-    }
-    return suggestions.get(deadline_type, "Review the deadline details and plan the next step")
+    return get_deadline_first_action(getattr(deadline, "deadline_type", None))
 
 
 def _build_notification_template_values(
@@ -558,15 +547,17 @@ class NotificationService:
         self.email_client = email_client or EmailClient()
         self.base_url = Config.BASE_URL.rstrip('/')
 
-    def build_sms_message(self, case_title: str, days_left: int, deadline_date: datetime) -> str:
+    def build_sms_message(self, case_title: str, days_left: int, deadline_date: datetime, first_action: Optional[str] = None) -> str:
         """Build SMS reminder message"""
         formatted_date = deadline_date.strftime("%d %b %Y")
+        action = (first_action or "").strip()
+        action_text = f" Next action: {action}." if action else ""
         return (
             f"⚖️ LegalAssist: Case '{case_title}' has a deadline in {days_left} day(s). "
-            f"Deadline: {formatted_date}. Log in to check details."
+            f"Deadline: {formatted_date}.{action_text} Log in to check details."
         )
 
-    def build_email_message(self, deadline: CaseDeadline, days_left: int) -> Tuple[str, str]:
+    def build_email_message(self, deadline: CaseDeadline, days_left: int, first_action: Optional[str] = None) -> Tuple[str, str]:
         """
         Build a premium email reminder content.
         Uses modern HTML/CSS with glassmorphism-inspired design.
@@ -576,6 +567,7 @@ class NotificationService:
         escaped_title = html.escape(getattr(deadline, 'case_title', ''))
         escaped_type = html.escape(deadline.deadline_type.title())
         escaped_desc = html.escape(deadline.description) if deadline.description else "No additional details provided."
+        escaped_action = html.escape((first_action or _derive_first_action(deadline)).strip())
         
         # Urgency color coding
         if days_left <= 3:
@@ -609,6 +601,8 @@ class NotificationService:
                 .deadline-label {{ color: #888; font-size: 13px; text-transform: uppercase; font-weight: 600; display: block; }}
                 .deadline-value {{ font-size: 18px; color: #222; font-weight: 600; }}
                 .description {{ background: #f9f9f9; padding: 20px; border-radius: 8px; font-style: italic; color: #666; margin-top: 20px; border-left: 3px solid #ddd; }}
+                .next-action {{ background: #eef6ff; padding: 18px 20px; border-radius: 10px; margin-top: 20px; border-left: 4px solid {accent_color}; }}
+                .next-action-label {{ display: block; color: #1a5490; font-size: 13px; font-weight: 700; text-transform: uppercase; margin-bottom: 6px; }}
                 .cta-button {{ display: inline-block; background: #1a5490; color: white !important; padding: 16px 40px; text-decoration: none; border-radius: 30px; font-weight: bold; margin-top: 30px; transition: all 0.3s ease; box-shadow: 0 4px 15px rgba(26, 84, 144, 0.3); }}
                 .footer {{ background: #f4f4f4; padding: 30px; text-align: center; color: #999; font-size: 12px; }}
                 .footer a {{ color: #1a5490; text-decoration: none; }}
@@ -643,6 +637,11 @@ class NotificationService:
                     <div class="deadline-label">Details</div>
                     <div class="description">
                         "{escaped_desc}"
+                    </div>
+
+                    <div class="next-action">
+                        <span class="next-action-label">Suggested Next Action</span>
+                        <span class="deadline-value">{escaped_action}</span>
                     </div>
 
                     <div style="text-align: center;">
@@ -704,6 +703,7 @@ class NotificationService:
                         getattr(deadline, "case_title", ""),
                         days_left,
                         deadline.deadline_date,
+                        _derive_first_action(deadline),
                     )
 
                 success, message_id, error = self.sms_client.send_sms(user_preference.phone_number, sms_message)
@@ -720,7 +720,7 @@ class NotificationService:
                     continue
 
                 if email_subject is None or email_html_content is None:
-                    email_subject, email_html_content = self.build_email_message(deadline, days_left)
+                    email_subject, email_html_content = self.build_email_message(deadline, days_left, _derive_first_action(deadline))
 
                 success, message_id, error = self.email_client.send_email(user_preference.email, email_subject, email_html_content)
                 final_channel = channel
@@ -826,7 +826,7 @@ class NotificationService:
             logger.exception("Error rendering user SMS template; falling back to default")
 
         if message is None:
-            message = self.build_sms_message(getattr(deadline, 'case_title', ''), days_left, deadline.deadline_date)
+            message = self.build_sms_message(getattr(deadline, 'case_title', ''), days_left, deadline.deadline_date, _derive_first_action(deadline))
 
         # Send SMS before writing to DB so a crash never leaves an orphan PENDING record.
         success, message_id, error = self.sms_client.send_sms(user_preference.phone_number, message)
@@ -910,7 +910,7 @@ class NotificationService:
             logger.exception("Error rendering user email template; falling back to default")
 
         if subject is None or html_content is None:
-            subject, html_content = self.build_email_message(deadline, days_left)
+            subject, html_content = self.build_email_message(deadline, days_left, _derive_first_action(deadline))
 
         # ====================================================================
         # ASYNCHRONOUS DELIVERY OFFLOAD

--- a/services/deadlines_auto_creator.py
+++ b/services/deadlines_auto_creator.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, ValidationError
 from sqlalchemy.orm import Session
 
 from db.models import CaseDeadline, CaseTimeline
+from core.deadline_engine import get_deadline_first_action
 from .timeline_service import timeline_service
 
 
@@ -214,6 +215,7 @@ def auto_create_deadlines_from_remedies(
         case_title=case_title,
         deadline_date=deadline_date,
         deadline_type="appeal",
+        first_action=get_deadline_first_action("appeal"),
         description=f"Appeal deadline - {validated_remedies.appeal_court or 'Unknown court'}",
     )
     db.add(deadline)

--- a/tests/test_deadline_engine.py
+++ b/tests/test_deadline_engine.py
@@ -1,4 +1,4 @@
-from core.deadline_engine import calculate_deadline
+from core.deadline_engine import calculate_deadline, get_deadline_first_action
 from datetime import datetime
 
 
@@ -33,3 +33,14 @@ def test_timezone_preserved_and_emergency_extension():
     assert res["deadline"].endswith("-04:00") or res["deadline"].endswith("-05:00")
     # emergency extension applied
     assert res["components"]["emergency_extension_days"] == 2
+
+
+def test_get_deadline_first_action_is_deterministic():
+    assert get_deadline_first_action("appeal") == "File appeal memo"
+    assert get_deadline_first_action("filing") == "Gather filing documents"
+    assert get_deadline_first_action("submission") == "Prepare and submit the required filing"
+    assert get_deadline_first_action("response") == "Draft the response and review supporting records"
+    assert get_deadline_first_action("hearing") == "Consult counsel and prepare the hearing bundle"
+    assert get_deadline_first_action("order") == "Review the order and confirm the next step"
+    assert get_deadline_first_action("manual") == "Review the deadline details and plan the next step"
+    assert get_deadline_first_action(None) == "Review the deadline details and plan the next step"


### PR DESCRIPTION
The smart next-action path is now wired end to end. `get_deadline_first_action(...)` lives in deadline_engine.py, deadline creation now stores `first_action` in notifications.py plus the direct creation paths in case_manager.py, deadlines_auto_creator.py, and deadlines.py. Reminder rendering now surfaces that action in SMS/email via notification_service.py, notification_service.py, and notification_service.py. I also added a deterministic mapping test in test_deadline_engine.py.

Validation passed for syntax compilation on the edited files, and a direct file-level assertion confirmed the mapping. A narrow pytest run was blocked by an unrelated missing dependency in this environment: `pypdf`.

closes #1344