### PR TITLE
feat: reminder effectiveness + drop-off

### DIFF
--- a/analytics_engine.py
+++ b/analytics_engine.py
@@ -1,8 +1,8 @@
 from typing import List, Dict, Optional, Tuple
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from sqlalchemy import func, case as sql_case
 from sqlalchemy.orm import Session, joinedload
-from database import CaseRecord, CaseOutcome, CaseAnalytics, UserFeedback, SimilarityFeedback
+from database import CaseRecord, CaseOutcome, CaseAnalytics, UserFeedback, SimilarityFeedback, CaseDeadline, CaseTimeline, NotificationLog, NotificationStatus, NotificationChannel, Case
 import hashlib
 import hmac
 import os
@@ -64,6 +64,19 @@ def _summary_overlap(s1: Optional[str], s2: Optional[str]) -> float:
     if not s1_clean or not s2_clean:
         return 0.0
     return difflib.SequenceMatcher(None, s1_clean, s2_clean).ratio()
+
+
+def _utc_datetime(value: Optional[datetime]) -> Optional[datetime]:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _normalize_group_value(value: Optional[str]) -> str:
+    text = str(value or "").strip()
+    return text or "Not specified"
 
 
 class MemoryOptimizationMixin:
@@ -1723,6 +1736,232 @@ class AnalyticsAggregator:
             
         results.sort(key=lambda x: x["total_cases"], reverse=True)
         return results
+
+
+class ReminderInsightsEngine:
+    """Compute reminder effectiveness and drop-off metrics from deadlines and notification logs."""
+
+    ELIGIBLE_STATUSES = {
+        NotificationStatus.SENT,
+        NotificationStatus.DELIVERED,
+        NotificationStatus.OPENED,
+    }
+
+    @staticmethod
+    def _completion_map(db: Session) -> Dict[int, datetime]:
+        completion_map: Dict[int, datetime] = {}
+        events = db.query(CaseTimeline).filter(CaseTimeline.event_type == "deadline_completed").all()
+        for event in events:
+            metadata = event.event_metadata if isinstance(event.event_metadata, dict) else {}
+            deadline_id = metadata.get("deadline_id")
+            try:
+                deadline_id_int = int(deadline_id)
+            except (TypeError, ValueError):
+                continue
+
+            completed_at = _utc_datetime(event.event_date)
+            if completed_at is None:
+                continue
+
+            current = completion_map.get(deadline_id_int)
+            if current is None or completed_at < current:
+                completion_map[deadline_id_int] = completed_at
+
+        return completion_map
+
+    @staticmethod
+    def build_attribution_frame(
+        db: Session,
+        attribution_window_days: int = 14,
+        user_id: Optional[int] = None,
+        jurisdiction: Optional[str] = None,
+        court_name: Optional[str] = None,
+        deadline_type: Optional[str] = None,
+        channel: Optional[NotificationChannel | str] = None,
+    ) -> pd.DataFrame:
+        now = datetime.now(timezone.utc)
+        completion_map = ReminderInsightsEngine._completion_map(db)
+
+        query = db.query(NotificationLog, CaseDeadline, Case).join(
+            CaseDeadline,
+            NotificationLog.deadline_id == CaseDeadline.id,
+        ).join(
+            Case,
+            CaseDeadline.case_id == Case.id,
+        )
+
+        if user_id is not None:
+            query = query.filter(Case.user_id == user_id)
+
+        if jurisdiction:
+            query = query.filter(func.lower(Case.jurisdiction) == _normalize_text(jurisdiction))
+        if court_name:
+            query = query.filter(func.lower(func.coalesce(CaseDeadline.court_name, "")) == _normalize_text(court_name))
+        if deadline_type:
+            query = query.filter(func.lower(CaseDeadline.deadline_type) == _normalize_text(deadline_type))
+        if channel:
+            channel_enum = channel if isinstance(channel, NotificationChannel) else NotificationChannel(str(channel).strip().lower())
+            query = query.filter(NotificationLog.channel == channel_enum)
+
+        deadline_buckets: Dict[int, Dict[str, object]] = {}
+        window = timedelta(days=max(1, int(attribution_window_days)))
+
+        for log, deadline, case in query.all():
+            if log.status not in ReminderInsightsEngine.ELIGIBLE_STATUSES:
+                continue
+
+            sent_at = _utc_datetime(log.sent_at or log.created_at)
+            deadline_date = _utc_datetime(deadline.deadline_date)
+            completion_at = completion_map.get(deadline.id)
+            if sent_at is None or deadline_date is None:
+                continue
+
+            bucket = deadline_buckets.setdefault(
+                deadline.id,
+                {
+                    "deadline": deadline,
+                    "case": case,
+                    "completion_at": completion_at,
+                    "candidates": [],
+                },
+            )
+            candidates = bucket["candidates"]
+            if isinstance(candidates, list):
+                candidates.append(
+                    {
+                        "notification_log_id": log.id,
+                        "channel": log.channel.value if hasattr(log.channel, "value") else str(log.channel),
+                        "sent_at": sent_at,
+                    }
+                )
+
+        rows = []
+        for deadline_id, bucket in deadline_buckets.items():
+            deadline = bucket["deadline"]
+            case = bucket["case"]
+            completion_at = bucket["completion_at"]
+            candidates = bucket["candidates"] if isinstance(bucket["candidates"], list) else []
+            deadline_date = _utc_datetime(deadline.deadline_date)
+            if deadline_date is None:
+                continue
+
+            cutoff = completion_at or min(deadline_date, now)
+            eligible_candidates = [candidate for candidate in candidates if candidate["sent_at"] <= cutoff]
+            if not eligible_candidates:
+                continue
+
+            chosen = max(eligible_candidates, key=lambda candidate: candidate["sent_at"])
+            sent_at = chosen["sent_at"]
+
+            matured = completion_at is not None or deadline_date <= now
+            effective = bool(completion_at and sent_at <= completion_at <= sent_at + window)
+            drop_off = bool(matured and not effective)
+            if not (effective or drop_off):
+                continue
+
+            days_to_completion = None
+            if effective and completion_at is not None:
+                days_to_completion = round((completion_at - sent_at).total_seconds() / 86400.0, 2)
+
+            rows.append(
+                {
+                    "deadline_id": deadline_id,
+                    "notification_log_id": chosen["notification_log_id"],
+                    "jurisdiction": _normalize_group_value(case.jurisdiction),
+                    "court_name": _normalize_group_value(getattr(deadline, "court_name", None)),
+                    "deadline_type": _normalize_group_value(deadline.deadline_type),
+                    "channel": chosen["channel"],
+                    "sent_at": sent_at,
+                    "completion_at": completion_at,
+                    "deadline_date": deadline_date,
+                    "effective": effective,
+                    "drop_off": drop_off,
+                    "days_to_completion": days_to_completion,
+                }
+            )
+
+        return pd.DataFrame(rows)
+
+    @staticmethod
+    def summarize(frame: pd.DataFrame, attribution_window_days: int = 14) -> Dict[str, object]:
+        if frame.empty:
+            return {
+                "attribution_window_days": attribution_window_days,
+                "reminder_count": 0,
+                "effective_reminders": 0,
+                "drop_off_reminders": 0,
+                "effectiveness_rate": 0.0,
+                "drop_off_rate": 0.0,
+                "avg_days_to_completion": None,
+            }
+
+        reminder_count = int(len(frame))
+        effective_reminders = int(frame["effective"].sum())
+        drop_off_reminders = int(frame["drop_off"].sum())
+        completed_days = frame.loc[frame["effective"], "days_to_completion"].dropna()
+
+        return {
+            "attribution_window_days": attribution_window_days,
+            "reminder_count": reminder_count,
+            "effective_reminders": effective_reminders,
+            "drop_off_reminders": drop_off_reminders,
+            "effectiveness_rate": round((effective_reminders / reminder_count) * 100, 1) if reminder_count else 0.0,
+            "drop_off_rate": round((drop_off_reminders / reminder_count) * 100, 1) if reminder_count else 0.0,
+            "avg_days_to_completion": round(float(completed_days.mean()), 2) if not completed_days.empty else None,
+        }
+
+    @staticmethod
+    def breakdown(frame: pd.DataFrame, group_by: str) -> pd.DataFrame:
+        if frame.empty or group_by not in frame.columns:
+            return pd.DataFrame(columns=[group_by, "reminders", "effective_reminders", "drop_off_reminders", "effectiveness_rate", "drop_off_rate", "avg_days_to_completion"])
+
+        grouped = frame.groupby(group_by, dropna=False).agg(
+            reminders=("notification_log_id", "count"),
+            effective_reminders=("effective", "sum"),
+            drop_off_reminders=("drop_off", "sum"),
+            avg_days_to_completion=("days_to_completion", "mean"),
+        ).reset_index()
+
+        grouped["effectiveness_rate"] = grouped.apply(
+            lambda row: round((row["effective_reminders"] / row["reminders"]) * 100, 1) if row["reminders"] else 0.0,
+            axis=1,
+        )
+        grouped["drop_off_rate"] = grouped.apply(
+            lambda row: round((row["drop_off_reminders"] / row["reminders"]) * 100, 1) if row["reminders"] else 0.0,
+            axis=1,
+        )
+        grouped["avg_days_to_completion"] = grouped["avg_days_to_completion"].round(2)
+        grouped = grouped.sort_values(["effectiveness_rate", "reminders"], ascending=[False, False]).reset_index(drop=True)
+        return grouped
+
+    @staticmethod
+    def build_insights(
+        db: Session,
+        attribution_window_days: int = 14,
+        user_id: Optional[int] = None,
+        jurisdiction: Optional[str] = None,
+        court_name: Optional[str] = None,
+        deadline_type: Optional[str] = None,
+        channel: Optional[NotificationChannel | str] = None,
+    ) -> Dict[str, object]:
+        frame = ReminderInsightsEngine.build_attribution_frame(
+            db=db,
+            attribution_window_days=attribution_window_days,
+            user_id=user_id,
+            jurisdiction=jurisdiction,
+            court_name=court_name,
+            deadline_type=deadline_type,
+            channel=channel,
+        )
+
+        return {
+            "summary": ReminderInsightsEngine.summarize(frame, attribution_window_days=attribution_window_days),
+            "frame": frame,
+            "by_jurisdiction": ReminderInsightsEngine.breakdown(frame, "jurisdiction"),
+            "by_court": ReminderInsightsEngine.breakdown(frame, "court_name"),
+            "by_deadline_type": ReminderInsightsEngine.breakdown(frame, "deadline_type"),
+            "by_channel": ReminderInsightsEngine.breakdown(frame, "channel"),
+        }
 
 
 # Utility function to anonymize case ID

--- a/api/routes/deadlines.py
+++ b/api/routes/deadlines.py
@@ -14,6 +14,7 @@ from datetime import datetime, timedelta, timezone
 
 from database import Case, CaseDeadline
 from api.dependencies import get_db_rls
+from core.deadline_engine import get_deadline_first_action
 
 router = APIRouter(prefix="/api/v1/deadlines", tags=["deadlines"])
 logger = structlog.get_logger(__name__)
@@ -281,10 +282,10 @@ async def create_deadline(
             """
             INSERT INTO case_deadlines (
                 user_id, case_id, case_title, deadline_date, deadline_type,
-                description, created_at, updated_at, is_completed, status
+                first_action, description, created_at, updated_at, is_completed, status
             ) VALUES (
                 :user_id, :case_id, :case_title, :deadline_date, :deadline_type,
-                :description, :created_at, :updated_at, :is_completed, :status
+                :first_action, :description, :created_at, :updated_at, :is_completed, :status
             )
             """
         ),
@@ -294,6 +295,7 @@ async def create_deadline(
             "case_title": case["title"] or case["case_number"],
             "deadline_date": normalized_due_date,
             "deadline_type": priority or "manual",
+            "first_action": get_deadline_first_action(priority or "manual"),
             "description": description or title,
             "created_at": now,
             "updated_at": now,

--- a/case_manager.py
+++ b/case_manager.py
@@ -850,6 +850,7 @@ def add_manual_deadline(
     deadline_date: datetime,
     deadline_type: str,
     description: Optional[str] = None,
+    court_name: Optional[str] = None,
 ) -> Optional[CaseDeadline]:
     """Add a manual deadline to a case"""
     if deadline_date.tzinfo is None:
@@ -866,6 +867,7 @@ def add_manual_deadline(
             user_id=user_id,
             case_id=case_id,
             case_title=case_title,
+            court_name=court_name,
             deadline_date=deadline_date,
             deadline_type=deadline_type,
             first_action=get_deadline_first_action(deadline_type),

--- a/case_manager.py
+++ b/case_manager.py
@@ -56,6 +56,7 @@ from database import (
     get_attachments_for_case,
     save_case_note_draft,
 )
+from core.deadline_engine import get_deadline_first_action
 from db.case_service import get_case_note, publish_case_note, get_case_note_history
 from services.timeline_service import timeline_service as _timeline_service
 from services.deadlines_auto_creator import (
@@ -867,6 +868,7 @@ def add_manual_deadline(
             case_title=case_title,
             deadline_date=deadline_date,
             deadline_type=deadline_type,
+            first_action=get_deadline_first_action(deadline_type),
             description=description,
         )
         db.add(deadline)

--- a/core/deadline_engine.py
+++ b/core/deadline_engine.py
@@ -147,3 +147,24 @@ def calculate_deadline(
 
 
 __all__ = ["calculate_deadline"]
+
+
+_DEADLINE_TYPE_FIRST_ACTIONS: Dict[str, str] = {
+    "appeal": "File appeal memo",
+    "filing": "Gather filing documents",
+    "submission": "Prepare and submit the required filing",
+    "response": "Draft the response and review supporting records",
+    "hearing": "Consult counsel and prepare the hearing bundle",
+    "order": "Review the order and confirm the next step",
+    "other": "Review the deadline details and plan the next step",
+    "manual": "Review the deadline details and plan the next step",
+}
+
+
+def get_deadline_first_action(deadline_type: Optional[str]) -> str:
+    """Return a short deterministic next-action suggestion for a deadline type."""
+    normalized = str(deadline_type or "other").strip().lower()
+    return _DEADLINE_TYPE_FIRST_ACTIONS.get(normalized, "Review the deadline details and plan the next step")
+
+
+__all__.append("get_deadline_first_action")

--- a/db/crud/notifications.py
+++ b/db/crud/notifications.py
@@ -206,6 +206,7 @@ def create_case_deadline(
     deadline_date: dt.datetime,
     deadline_type: str,
     description: Optional[str] = None,
+    court_name: Optional[str] = None,
 ) -> CaseDeadline:
     try:
         normalized_case_id = int(case_id)
@@ -222,6 +223,7 @@ def create_case_deadline(
         user_id=user_id,
         case_id=normalized_case_id,
         case_title=case_title,
+        court_name=court_name,
         deadline_date=deadline_date,
         deadline_type=deadline_type,
         first_action=get_deadline_first_action(deadline_type),

--- a/db/crud/notifications.py
+++ b/db/crud/notifications.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session
 from db.models.notifications import NotificationLog, NotificationStatus, NotificationChannel, NotificationTemplate, UserPreference
 from db.models.cases import CaseDeadline, Case
 from sqlalchemy.exc import IntegrityError
+from core.deadline_engine import get_deadline_first_action
 
 
 def get_or_create_notification_log(
@@ -223,6 +224,7 @@ def create_case_deadline(
         case_title=case_title,
         deadline_date=deadline_date,
         deadline_type=deadline_type,
+        first_action=get_deadline_first_action(deadline_type),
         description=description,
     )
     db.add(deadline)

--- a/db/models/cases.py
+++ b/db/models/cases.py
@@ -49,6 +49,7 @@ class CaseDeadline(Base):
     user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=False)
     case_id = Column(Integer, ForeignKey("cases.id", ondelete="CASCADE"), nullable=False, index=True)
     case_title = Column(String(255), nullable=False)
+    court_name = Column(String(255), nullable=True)
     deadline_date = Column(DateTime(timezone=True), nullable=False, index=True)
     deadline_type = Column(String(255), nullable=False)
     first_action = Column(String(255), nullable=True)

--- a/db/models/cases.py
+++ b/db/models/cases.py
@@ -51,6 +51,7 @@ class CaseDeadline(Base):
     case_title = Column(String(255), nullable=False)
     deadline_date = Column(DateTime(timezone=True), nullable=False, index=True)
     deadline_type = Column(String(255), nullable=False)
+    first_action = Column(String(255), nullable=True)
     description = Column(Text, nullable=True)
     created_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), nullable=False)
     updated_at = Column(DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), onupdate=lambda: dt.datetime.now(dt.timezone.utc))

--- a/notification_service.py
+++ b/notification_service.py
@@ -71,6 +71,7 @@ from db.crud.notifications import (
 )
 from db.crud.audit import record_immutable_audit_event
 from core.template_renderer import render_template, validate_template, TemplateValidationError
+from core.deadline_engine import get_deadline_first_action
 from core.log_redaction import mask_recipient, sanitize_log_text
 from services.timeline_service import timeline_service as case_timeline_service
 
@@ -112,23 +113,11 @@ def _template_language_key(language: Optional[str]) -> str:
 
 
 def _derive_first_action(deadline: CaseDeadline) -> str:
-    description = (getattr(deadline, "description", "") or "").strip()
-    if description:
-        first_sentence = re.split(r"(?<=[.!?])\s+", description, maxsplit=1)[0].strip()
-        if len(first_sentence) > 140:
-            first_sentence = first_sentence[:137].rstrip() + "..."
-        return first_sentence
+    stored_action = (getattr(deadline, "first_action", None) or "").strip()
+    if stored_action:
+        return stored_action
 
-    deadline_type = str(getattr(deadline, "deadline_type", "") or "").strip().lower()
-    suggestions = {
-        "appeal": "Draft and file the appeal",
-        "filing": "Prepare and submit the filing",
-        "submission": "Gather the required documents and submit them",
-        "response": "Prepare the response and verify deadlines",
-        "hearing": "Review the hearing strategy and supporting documents",
-        "other": "Review the deadline details and plan the next step",
-    }
-    return suggestions.get(deadline_type, "Review the deadline details and plan the next step")
+    return get_deadline_first_action(getattr(deadline, "deadline_type", None))
 
 
 def _build_notification_template_values(
@@ -558,15 +547,17 @@ class NotificationService:
         self.email_client = email_client or EmailClient()
         self.base_url = Config.BASE_URL.rstrip('/')
 
-    def build_sms_message(self, case_title: str, days_left: int, deadline_date: datetime) -> str:
+    def build_sms_message(self, case_title: str, days_left: int, deadline_date: datetime, first_action: Optional[str] = None) -> str:
         """Build SMS reminder message"""
         formatted_date = deadline_date.strftime("%d %b %Y")
+        action = (first_action or "").strip()
+        action_text = f" Next action: {action}." if action else ""
         return (
             f"⚖️ LegalAssist: Case '{case_title}' has a deadline in {days_left} day(s). "
-            f"Deadline: {formatted_date}. Log in to check details."
+            f"Deadline: {formatted_date}.{action_text} Log in to check details."
         )
 
-    def build_email_message(self, deadline: CaseDeadline, days_left: int) -> Tuple[str, str]:
+    def build_email_message(self, deadline: CaseDeadline, days_left: int, first_action: Optional[str] = None) -> Tuple[str, str]:
         """
         Build a premium email reminder content.
         Uses modern HTML/CSS with glassmorphism-inspired design.
@@ -576,6 +567,7 @@ class NotificationService:
         escaped_title = html.escape(getattr(deadline, 'case_title', ''))
         escaped_type = html.escape(deadline.deadline_type.title())
         escaped_desc = html.escape(deadline.description) if deadline.description else "No additional details provided."
+        escaped_action = html.escape((first_action or _derive_first_action(deadline)).strip())
         
         # Urgency color coding
         if days_left <= 3:
@@ -609,6 +601,8 @@ class NotificationService:
                 .deadline-label {{ color: #888; font-size: 13px; text-transform: uppercase; font-weight: 600; display: block; }}
                 .deadline-value {{ font-size: 18px; color: #222; font-weight: 600; }}
                 .description {{ background: #f9f9f9; padding: 20px; border-radius: 8px; font-style: italic; color: #666; margin-top: 20px; border-left: 3px solid #ddd; }}
+                .next-action {{ background: #eef6ff; padding: 18px 20px; border-radius: 10px; margin-top: 20px; border-left: 4px solid {accent_color}; }}
+                .next-action-label {{ display: block; color: #1a5490; font-size: 13px; font-weight: 700; text-transform: uppercase; margin-bottom: 6px; }}
                 .cta-button {{ display: inline-block; background: #1a5490; color: white !important; padding: 16px 40px; text-decoration: none; border-radius: 30px; font-weight: bold; margin-top: 30px; transition: all 0.3s ease; box-shadow: 0 4px 15px rgba(26, 84, 144, 0.3); }}
                 .footer {{ background: #f4f4f4; padding: 30px; text-align: center; color: #999; font-size: 12px; }}
                 .footer a {{ color: #1a5490; text-decoration: none; }}
@@ -643,6 +637,11 @@ class NotificationService:
                     <div class="deadline-label">Details</div>
                     <div class="description">
                         "{escaped_desc}"
+                    </div>
+
+                    <div class="next-action">
+                        <span class="next-action-label">Suggested Next Action</span>
+                        <span class="deadline-value">{escaped_action}</span>
                     </div>
 
                     <div style="text-align: center;">
@@ -704,6 +703,7 @@ class NotificationService:
                         getattr(deadline, "case_title", ""),
                         days_left,
                         deadline.deadline_date,
+                        _derive_first_action(deadline),
                     )
 
                 success, message_id, error = self.sms_client.send_sms(user_preference.phone_number, sms_message)
@@ -720,7 +720,7 @@ class NotificationService:
                     continue
 
                 if email_subject is None or email_html_content is None:
-                    email_subject, email_html_content = self.build_email_message(deadline, days_left)
+                    email_subject, email_html_content = self.build_email_message(deadline, days_left, _derive_first_action(deadline))
 
                 success, message_id, error = self.email_client.send_email(user_preference.email, email_subject, email_html_content)
                 final_channel = channel
@@ -826,7 +826,7 @@ class NotificationService:
             logger.exception("Error rendering user SMS template; falling back to default")
 
         if message is None:
-            message = self.build_sms_message(getattr(deadline, 'case_title', ''), days_left, deadline.deadline_date)
+            message = self.build_sms_message(getattr(deadline, 'case_title', ''), days_left, deadline.deadline_date, _derive_first_action(deadline))
 
         # Send SMS before writing to DB so a crash never leaves an orphan PENDING record.
         success, message_id, error = self.sms_client.send_sms(user_preference.phone_number, message)
@@ -910,7 +910,7 @@ class NotificationService:
             logger.exception("Error rendering user email template; falling back to default")
 
         if subject is None or html_content is None:
-            subject, html_content = self.build_email_message(deadline, days_left)
+            subject, html_content = self.build_email_message(deadline, days_left, _derive_first_action(deadline))
 
         # ====================================================================
         # ASYNCHRONOUS DELIVERY OFFLOAD

--- a/pages/7_Reminder_Insights.py
+++ b/pages/7_Reminder_Insights.py
@@ -1,0 +1,223 @@
+"""
+Reminder Insights - LegalAssist AI.
+Tracks reminder effectiveness and drop-off after notification delivery.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime
+
+import pandas as pd
+import plotly.express as px
+import streamlit as st
+
+# Add parent directory to sys.path to resolve project modules.
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from auth import get_current_user_id, redirect_to_login, require_auth
+from analytics_engine import ReminderInsightsEngine
+from database import SessionLocal
+
+
+st.set_page_config(
+    page_title="Reminder Insights - LegalAssist AI",
+    page_icon="📣",
+    layout="wide",
+)
+
+st.markdown(
+    """
+    <style>
+        .insights-hero {
+            padding: 24px 28px;
+            border-radius: 22px;
+            background: linear-gradient(135deg, #0f172a 0%, #111827 55%, #1f2937 100%);
+            color: #f8fafc;
+            border: 1px solid rgba(255,255,255,0.08);
+            box-shadow: 0 18px 50px rgba(15, 23, 42, 0.20);
+            margin-bottom: 1.5rem;
+        }
+        .insights-hero h1 { margin: 0; font-size: 2.1rem; }
+        .insights-hero p { margin: 0.5rem 0 0; color: rgba(248,250,252,0.82); }
+        .metric-card {
+            background: linear-gradient(180deg, rgba(255,255,255,0.92), rgba(248,250,252,0.78));
+            border: 1px solid rgba(15,23,42,0.08);
+            border-radius: 18px;
+            padding: 18px 20px;
+            box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+        }
+        .section-chip {
+            display: inline-block;
+            padding: 0.35rem 0.7rem;
+            border-radius: 999px;
+            background: #e0f2fe;
+            color: #075985;
+            font-size: 0.78rem;
+            font-weight: 700;
+            letter-spacing: 0.02em;
+            text-transform: uppercase;
+        }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
+
+def _render_metric(label: str, value: str, help_text: str, accent: str) -> None:
+    st.markdown(
+        f"""
+        <div class="metric-card">
+            <div style="color: #475569; font-size: 0.85rem; font-weight: 700; text-transform: uppercase;">{label}</div>
+            <div style="margin-top: 0.35rem; font-size: 1.8rem; font-weight: 800; color: {accent};">{value}</div>
+            <div style="margin-top: 0.35rem; color: #64748b; font-size: 0.84rem;">{help_text}</div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def _render_breakdown_chart(title: str, frame: pd.DataFrame, group_col: str, color: str) -> None:
+    st.markdown(f"<span class='section-chip'>{title}</span>", unsafe_allow_html=True)
+    if frame.empty:
+        st.info(f"No reminder data available for {title.lower()}.")
+        return
+
+    chart_frame = frame.head(10).copy()
+    fig = px.bar(
+        chart_frame,
+        x=group_col,
+        y="effectiveness_rate",
+        color="drop_off_rate",
+        color_continuous_scale=["#fde68a", "#f97316", "#b91c1c"],
+        text="effectiveness_rate",
+        hover_data={
+            "reminders": True,
+            "effective_reminders": True,
+            "drop_off_reminders": True,
+            "avg_days_to_completion": True,
+            "effectiveness_rate": True,
+            "drop_off_rate": True,
+        },
+        labels={
+            group_col: title,
+            "effectiveness_rate": "Effectiveness %",
+            "drop_off_rate": "Drop-off %",
+        },
+        title=None,
+    )
+    fig.update_traces(texttemplate="%{text:.1f}%", textposition="outside")
+    fig.update_layout(
+        height=420,
+        margin=dict(l=0, r=0, t=10, b=0),
+        coloraxis_colorbar=dict(title="Drop-off %"),
+        xaxis_title=None,
+        yaxis_title="Effectiveness %",
+        template="plotly_white",
+    )
+    st.plotly_chart(fig, use_container_width=True)
+    st.dataframe(chart_frame, use_container_width=True, hide_index=True)
+
+
+if not require_auth():
+    redirect_to_login()
+    st.stop()
+
+user_id = get_current_user_id()
+
+st.markdown(
+    """
+    <div class="insights-hero">
+        <h1>📣 Reminder Insights</h1>
+        <p>Effectiveness is measured using the latest reminder sent before a deadline is completed. Deadlines that are still future-dated are excluded from drop-off counts.</p>
+    </div>
+    """,
+    unsafe_allow_html=True,
+)
+
+attribution_window_days = st.slider(
+    "Attribution window (days)",
+    min_value=1,
+    max_value=30,
+    value=14,
+    help="A reminder is considered effective if the deadline is completed within this many days after the send time.",
+)
+
+st.caption("Court is shown only when stored on the deadline record; older rows may appear as Not specified.")
+
+with SessionLocal() as db:
+    insights = ReminderInsightsEngine.build_insights(
+        db=db,
+        attribution_window_days=attribution_window_days,
+        user_id=user_id,
+    )
+
+summary = insights["summary"]
+frame = insights["frame"]
+by_jurisdiction = insights["by_jurisdiction"]
+by_court = insights["by_court"]
+by_deadline_type = insights["by_deadline_type"]
+by_channel = insights["by_channel"]
+
+if st.button("Refresh insights", use_container_width=False):
+    st.rerun()
+
+metric_cols = st.columns(5)
+with metric_cols[0]:
+    _render_metric("Attributed reminders", str(summary["reminder_count"]), "Resolved reminders included in the selected attribution window.", "#0f766e")
+with metric_cols[1]:
+    _render_metric("Effective", str(summary["effective_reminders"]), "Attributed reminders followed by a completion event in-window.", "#15803d")
+with metric_cols[2]:
+    _render_metric("Drop-off", str(summary["drop_off_reminders"]), "Matured deadlines without an effective reminder outcome.", "#b45309")
+with metric_cols[3]:
+    _render_metric("Effectiveness", f"{summary['effectiveness_rate']:.1f}%", "Share of attributed reminders that led to completion.", "#1d4ed8")
+with metric_cols[4]:
+    avg_days = "-" if summary["avg_days_to_completion"] is None else f"{summary['avg_days_to_completion']:.2f}"
+    _render_metric("Avg completion lag", avg_days, "Average days between the attributed reminder and completion.", "#7c3aed")
+
+st.markdown("---")
+
+if frame.empty:
+    st.info("No reminder analytics data is available for your account yet.")
+else:
+    tab_jurisdiction, tab_court, tab_deadline_type, tab_channel, tab_details = st.tabs(
+        ["By Jurisdiction", "By Court", "By Deadline Type", "By Channel", "Details"]
+    )
+
+    with tab_jurisdiction:
+        _render_breakdown_chart("Jurisdiction", by_jurisdiction, "jurisdiction", "effectiveness_rate")
+
+    with tab_court:
+        _render_breakdown_chart("Court", by_court, "court_name", "effectiveness_rate")
+
+    with tab_deadline_type:
+        _render_breakdown_chart("Deadline Type", by_deadline_type, "deadline_type", "effectiveness_rate")
+
+    with tab_channel:
+        _render_breakdown_chart("Channel", by_channel, "channel", "effectiveness_rate")
+
+    with tab_details:
+        detail_frame = frame.copy().sort_values(["sent_at", "deadline_id"], ascending=[False, False])
+        detail_frame = detail_frame[[
+            "deadline_id",
+            "notification_log_id",
+            "jurisdiction",
+            "court_name",
+            "deadline_type",
+            "channel",
+            "sent_at",
+            "completion_at",
+            "effective",
+            "drop_off",
+            "days_to_completion",
+        ]]
+        st.dataframe(detail_frame.head(50), use_container_width=True, hide_index=True)
+
+        csv_bytes = detail_frame.to_csv(index=False).encode("utf-8")
+        st.download_button(
+            "Download reminder insights CSV",
+            data=csv_bytes,
+            file_name=f"reminder_insights_{datetime.now().strftime('%Y%m%d_%H%M%S')}.csv",
+            mime="text/csv",
+        )

--- a/services/deadlines_auto_creator.py
+++ b/services/deadlines_auto_creator.py
@@ -213,6 +213,7 @@ def auto_create_deadlines_from_remedies(
         user_id=user_id,
         case_id=case_id,
         case_title=case_title,
+        court_name=validated_remedies.appeal_court,
         deadline_date=deadline_date,
         deadline_type="appeal",
         first_action=get_deadline_first_action("appeal"),

--- a/services/deadlines_auto_creator.py
+++ b/services/deadlines_auto_creator.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, ValidationError
 from sqlalchemy.orm import Session
 
 from db.models import CaseDeadline, CaseTimeline
+from core.deadline_engine import get_deadline_first_action
 from .timeline_service import timeline_service
 
 
@@ -214,6 +215,7 @@ def auto_create_deadlines_from_remedies(
         case_title=case_title,
         deadline_date=deadline_date,
         deadline_type="appeal",
+        first_action=get_deadline_first_action("appeal"),
         description=f"Appeal deadline - {validated_remedies.appeal_court or 'Unknown court'}",
     )
     db.add(deadline)

--- a/tests/test_deadline_engine.py
+++ b/tests/test_deadline_engine.py
@@ -1,4 +1,4 @@
-from core.deadline_engine import calculate_deadline
+from core.deadline_engine import calculate_deadline, get_deadline_first_action
 from datetime import datetime
 
 
@@ -33,3 +33,14 @@ def test_timezone_preserved_and_emergency_extension():
     assert res["deadline"].endswith("-04:00") or res["deadline"].endswith("-05:00")
     # emergency extension applied
     assert res["components"]["emergency_extension_days"] == 2
+
+
+def test_get_deadline_first_action_is_deterministic():
+    assert get_deadline_first_action("appeal") == "File appeal memo"
+    assert get_deadline_first_action("filing") == "Gather filing documents"
+    assert get_deadline_first_action("submission") == "Prepare and submit the required filing"
+    assert get_deadline_first_action("response") == "Draft the response and review supporting records"
+    assert get_deadline_first_action("hearing") == "Consult counsel and prepare the hearing bundle"
+    assert get_deadline_first_action("order") == "Review the order and confirm the next step"
+    assert get_deadline_first_action("manual") == "Review the deadline details and plan the next step"
+    assert get_deadline_first_action(None) == "Review the deadline details and plan the next step"

--- a/tests/test_reminder_insights.py
+++ b/tests/test_reminder_insights.py
@@ -1,0 +1,166 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from analytics_engine import ReminderInsightsEngine
+from db.base import Base
+from db.models import Case, CaseDeadline, CaseTimeline, NotificationChannel, NotificationLog, NotificationStatus, User
+
+
+@pytest.fixture()
+def test_db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _create_case(db, user_id: int, case_number: str, jurisdiction: str, title: str, court_name: str) -> Case:
+    case = Case(
+        user_id=user_id,
+        case_number=case_number,
+        case_type="civil",
+        jurisdiction=jurisdiction,
+        title=title,
+    )
+    db.add(case)
+    db.flush()
+    return case
+
+
+def _create_deadline(
+    db,
+    user_id: int,
+    case: Case,
+    deadline_type: str,
+    court_name: str,
+    deadline_date: datetime,
+    is_completed: bool,
+) -> CaseDeadline:
+    deadline = CaseDeadline(
+        user_id=user_id,
+        case_id=case.id,
+        case_title=case.title or case.case_number,
+        court_name=court_name,
+        deadline_date=deadline_date,
+        deadline_type=deadline_type,
+        first_action="Review the deadline details and plan the next step",
+        is_completed=is_completed,
+        status="completed" if is_completed else "active",
+    )
+    db.add(deadline)
+    db.flush()
+    return deadline
+
+
+class TestReminderInsightsEngine:
+    def test_build_insights_uses_last_touch_and_groups_by_dimensions(self, test_db):
+        user = User(email="insights@example.com")
+        test_db.add(user)
+        test_db.flush()
+
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+
+        delhi_case = _create_case(test_db, user.id, "CASE-DELHI", "Delhi", "Delhi matter", "High Court")
+        mumbai_case = _create_case(test_db, user.id, "CASE-MUM", "Mumbai", "Mumbai matter", "District Court")
+
+        effective_deadline = _create_deadline(
+            test_db,
+            user.id,
+            delhi_case,
+            "appeal",
+            "High Court",
+            now - timedelta(days=1),
+            True,
+        )
+        effective_sent_early = now - timedelta(days=10)
+        effective_sent_latest = now - timedelta(days=9)
+        earlier_log = NotificationLog(
+            deadline_id=effective_deadline.id,
+            user_id=user.id,
+            channel=NotificationChannel.SMS,
+            status=NotificationStatus.SENT,
+            recipient="+10000000000",
+            days_before=10,
+            sent_at=effective_sent_early,
+        )
+        latest_log = NotificationLog(
+            deadline_id=effective_deadline.id,
+            user_id=user.id,
+            channel=NotificationChannel.SMS,
+            status=NotificationStatus.DELIVERED,
+            recipient="+10000000000",
+            days_before=9,
+            sent_at=effective_sent_latest,
+            delivered_at=effective_sent_latest + timedelta(hours=2),
+        )
+        test_db.add_all([earlier_log, latest_log])
+        test_db.flush()
+
+        test_db.add(
+            CaseTimeline(
+                case_id=delhi_case.id,
+                event_type="deadline_completed",
+                description="Marked appeal deadline as completed",
+                event_date=effective_sent_latest + timedelta(days=2),
+                event_metadata={"deadline_id": effective_deadline.id},
+            )
+        )
+
+        dropoff_deadline = _create_deadline(
+            test_db,
+            user.id,
+            mumbai_case,
+            "response",
+            "District Court",
+            now - timedelta(days=3),
+            False,
+        )
+        dropoff_log = NotificationLog(
+            deadline_id=dropoff_deadline.id,
+            user_id=user.id,
+            channel=NotificationChannel.EMAIL,
+            status=NotificationStatus.SENT,
+            recipient="user@example.com",
+            days_before=7,
+            sent_at=now - timedelta(days=8),
+        )
+        test_db.add(dropoff_log)
+        test_db.commit()
+
+        insights = ReminderInsightsEngine.build_insights(test_db, attribution_window_days=14, user_id=user.id)
+
+        summary = insights["summary"]
+        frame = insights["frame"]
+        by_jurisdiction = insights["by_jurisdiction"]
+        by_court = insights["by_court"]
+        by_deadline_type = insights["by_deadline_type"]
+        by_channel = insights["by_channel"]
+
+        assert summary["reminder_count"] == 2
+        assert summary["effective_reminders"] == 1
+        assert summary["drop_off_reminders"] == 1
+        assert summary["effectiveness_rate"] == 50.0
+        assert len(frame) == 2
+
+        effective_row = frame.loc[frame["deadline_id"] == effective_deadline.id].iloc[0]
+        assert effective_row["notification_log_id"] == latest_log.id
+        assert bool(effective_row["effective"]) is True
+        assert bool(effective_row["drop_off"]) is False
+
+        dropoff_row = frame.loc[frame["deadline_id"] == dropoff_deadline.id].iloc[0]
+        assert bool(dropoff_row["effective"]) is False
+        assert bool(dropoff_row["drop_off"]) is True
+
+        assert set(by_jurisdiction["jurisdiction"]) == {"Delhi", "Mumbai"}
+        assert set(by_court["court_name"]) == {"High Court", "District Court"}
+        assert set(by_deadline_type["deadline_type"]) == {"appeal", "response"}
+        assert set(by_channel["channel"]) == {"sms", "email"}
+        assert int(by_channel.loc[by_channel["channel"] == "sms", "effective_reminders"].iloc[0]) == 1
+        assert int(by_channel.loc[by_channel["channel"] == "email", "drop_off_reminders"].iloc[0]) == 1


### PR DESCRIPTION
Implemented the reminder analytics feature end to end. The query layer now lives in analytics_engine.py as `ReminderInsightsEngine`, using notification logs plus deadline completion events to attribute each deadline to the latest eligible reminder within the selected window. I also added nullable `court_name` support on deadlines in cases.py, and created the new Streamlit dashboard page in 7_Reminder_Insights.py.

For coverage, I added a focused sample-data test in test_reminder_insights.py that verifies last-touch attribution and the jurisdiction/court/deadline_type/channel breakdowns.




closes #1345