### PR TITLE
UI Localization state desync bug in pp.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -593,7 +593,7 @@ def main():
     st.markdown(ui["app_intro"])
     st.markdown("---")
 
-    language = st.selectbox("🌐 Select your language", ["English", "Hindi", "Bengali", "Urdu"])
+    language = st.selectbox("🌐 Select your language", ["English", "Hindi", "Bengali", "Urdu"], key="judgment_language")
     uploaded_file = st.file_uploader("📄 Upload Judgment PDF / Image", type=["pdf", "jpg", "jpeg", "png", "tiff", "tif", "bmp"])
     enable_ocr = False
     ocr_languages = "eng+hin"


### PR DESCRIPTION
# Related Issue
Closes #1393

# Summary
This PR fixes a critical state desynchronization bug where the UI language was permanently locked to English. By properly binding the language dropdown to the Streamlit session state, the static UI elements now translate immediately when a user selects a new language.

# Changes Made
- Added the missing `key="judgment_language"` argument to the `st.selectbox` component in `app.py`.
- Ensured the selected dropdown value automatically syncs with `st.session_state` so the `get_localized_ui_text` function fetches the correct translations.

# Testing
- [x] Started the Streamlit application locally.
- [x] Selected different languages from the dropdown (e.g., Hindi, Bengali).
- [x] Verified that all static UI elements (headers, subtitles, labels) successfully and immediately translated to the chosen language.


# Impact
Restores full multi-lingual support to the UI, ensuring non-English speakers can successfully navigate and interact with the application.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered