### PR TITLE
the fatal AttributeError on initial load in pp.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -659,7 +659,7 @@ def main():
         st.session_state.last_language = language
 
     current_hash = hashlib.md5(uploaded_file.getvalue()).hexdigest() if uploaded_file else None
-    is_same_file = st.session_state.get("processed_file") == uploaded_file.name and st.session_state.get("processed_file_hash") == current_hash
+    is_same_file = (uploaded_file is not None) and (st.session_state.get("processed_file") == uploaded_file.name) and (st.session_state.get("processed_file_hash") == current_hash)
     if uploaded_file and is_same_file and st.session_state.get("last_language") == language:
         if not client:
             st.error(ui["openrouter_not_configured"])


### PR DESCRIPTION
# Related Issue
Closes #1391

# Summary
This PR resolves a critical bug where the application experienced a fatal crash immediately upon the initial page load. The issue occurred because the caching logic attempted to access `uploaded_file.name` before verifying if a file had actually been uploaded (resulting in an `AttributeError` on `NoneType`).

# Changes Made
- Added a `(uploaded_file is not None)` null check to the `is_same_file` validation logic in `app.py`.
- Ensured the short-circuiting logic prevents reading attributes of an empty file upload state.

# Testing
- [x] Started the Streamlit server locally (`streamlit run app.py`).
- [x] Navigated to the application URL and verified it loads smoothly without the `AttributeError` stack trace.
- [x] Uploaded a document to ensure the caching and processing logic still functions correctly.


# Impact
Prevents the UI from breaking entirely for first-time users and ensures a smooth, error-free initial application render.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered