### PR TITLE
the Image Processing OCR block bug

### DIFF
--- a/app.py
+++ b/app.py
@@ -633,17 +633,18 @@ def main():
             st.warning("⚠️ This file is quite large. Processing may take longer than usual.")
             
         # Check page count
-        try:
-            pdf_reader = PdfReader(uploaded_file)
-            num_pages = len(pdf_reader.pages)
-            if num_pages > 100:
-                st.warning(f"⚠️ This document has {num_pages} pages. Summaries of very long judgments may be less precise.")
-            if num_pages > 1000:
-                st.error("🛑 Extremely large PDF (1000+ pages) detected. Character limits will be exceeded, leading to a very poor summary. Please upload a shorter excerpt.")
+        if file_ext == "pdf":
+            try:
+                pdf_reader = PdfReader(uploaded_file)
+                num_pages = len(pdf_reader.pages)
+                if num_pages > 100:
+                    st.warning(f"⚠️ This document has {num_pages} pages. Summaries of very long judgments may be less precise.")
+                if num_pages > 1000:
+                    st.error("🛑 Extremely large PDF (1000+ pages) detected. Character limits will be exceeded, leading to a very poor summary. Please upload a shorter excerpt.")
+                    is_valid_pdf = False
+            except Exception as e:
+                st.error("Could not read PDF metadata. The file might be corrupted.")
                 is_valid_pdf = False
-        except Exception as e:
-            st.error("Could not read PDF metadata. The file might be corrupted.")
-            is_valid_pdf = False
 
     st.markdown("---")
 


### PR DESCRIPTION
# Related Issue
Closes #1392

# Summary
This PR fixes a critical logic flaw where valid image uploads (JPG, PNG) were being unconditionally fed into the `PdfReader` validation parser. This caused the parser to crash, incorrectly flagging the images as corrupted PDFs and permanently disabling the "Generate Summary" button for OCR processing.

# Changes Made
- Wrapped the document page-count validation block (`PdfReader` initialization) inside an `if` condition so it only executes for `.pdf` files.
- Ensured image files bypass PDF-specific metadata checks, allowing them to proceed smoothly to the OCR extraction pipeline.

# Testing
- [x] Started the Streamlit server locally.
- [x] Uploaded a valid PDF to ensure the page-count warning/error logic still works for PDFs.
- [x] Uploaded a valid image file (`.jpg` / `.png`) and verified that the "Could not read PDF metadata" error no longer appears.
- [x] Verified that the "Generate Summary" button remains enabled for image files, successfully triggering the OCR pipeline.



# Impact
Fully restores the application's intended Image Processing and OCR capabilities, allowing users to analyze image-based legal documents without being blocked.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered