### PR TITLE
the fatal NameError crash on startup in pp.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -44,6 +44,7 @@ from observability.integration import initialize_observability_for_environment
 
 # Initialize database
 from config import Config
+from database import init_db
 Config.validate_runtime_security()
 init_db()
 


### PR DESCRIPTION
# Related Issue
Closes #1383

# Summary
This PR resolves a critical startup crash where the application threw a fatal `NameError` immediately upon execution. The issue occurred because the database initialization function `init_db()` was being called in the global scope of `app.py` but was never imported.

# Changes Made
- Added the missing `init_db` import from the database module at the top of `app.py`.
- Ensured the application has the necessary references to successfully initialize the database before booting the Streamlit server.

# Testing
- [x] Started the Streamlit server locally (`streamlit run app.py`).
- [x] Verified that the application boots successfully without throwing `NameError: name 'init_db' is not defined` in the terminal.
- [x] Verified the application UI loads without crashing on startup.



# Impact
Allows the application to initialize properly and boot up successfully, preventing a complete blockade for all users attempting to run the project.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered
