### PR TITLE
fix(#1409): strip identifier prefix in is_whitelisted before WHITELIST lookup

### DIFF
--- a/api/limiter.py
+++ b/api/limiter.py
@@ -335,7 +335,14 @@ limiter = DistributedRateLimiter()
 
 
 def is_whitelisted(identifier: str) -> bool:
-    return identifier in WHITELIST
+    # resolve_rate_limit_identifier returns prefixed strings such as
+    # "ip:127.0.0.1" or "user:42", but WHITELIST stores bare values like
+    # "127.0.0.1".  Strip the type prefix before comparison so that
+    # localhost, loopback, and internal service identifiers are matched
+    # correctly.  The original identifier is also checked to support any
+    # future call sites that pass an unprefixed string directly.
+    _, _, bare_value = identifier.partition(":")
+    return bare_value in WHITELIST or identifier in WHITELIST
 
 
 def resolve_rate_limit_identifier(request: Request) -> str:


### PR DESCRIPTION
## Summary
Fixes the rate-limit whitelist that never matched because `resolve_rate_limit_identifier` returns prefixed strings (`ip:127.0.0.1`) while `WHITELIST` stores bare values (`127.0.0.1`).

## Related Issue
Closes #1409

## Type of Change
- [x] Bug fix

## Root Cause
```python
WHITELIST = {'127.0.0.1', '::1', 'localhost', 'internal-admin-service', ...}
def is_whitelisted(identifier: str) -> bool:
    return identifier in WHITELIST  # 'ip:127.0.0.1' never in WHITELIST
```

## What Changed
- `api/limiter.py`: strip the type prefix (everything up to and including the first colon) before the membership test. The full identifier is also checked as a fallback.

## Testing
- [ ] Requests from `127.0.0.1` are not rate-limited
- [ ] Requests from `internal-admin-service` are not rate-limited
- [ ] External IPs are still subject to rate limits

## Checklist
- [x] No hardcoded secrets or credentials
- [x] Single focused change