### PR TITLE
fix(#1410): replace hardcoded parties placeholder with data from extracted_metadata

### DIFF
--- a/api/routes/cases.py
+++ b/api/routes/cases.py
@@ -79,7 +79,11 @@ def _build_case_summary_payload(case: Case, latest_doc: CaseDocument | None = No
         "case_id": str(case.id),
         "case_number": case.case_number,
         "title": case.title or case.case_number,
-        "parties": ["Smith", "Jones"],  # Placeholder
+        "parties": (
+            (latest_doc.extracted_metadata or {}).get("parties", [])
+            if latest_doc and latest_doc.extracted_metadata
+            else []
+        ),
         "jurisdiction": case.jurisdiction,
         "status": case.status.value if hasattr(case.status, 'value') else str(case.status),
         "summary": latest_doc.summary if latest_doc else "",


### PR DESCRIPTION
## Summary
Replaces the hardcoded `['Smith', 'Jones']` party list in `_build_case_summary_payload` with actual party data extracted from case documents.

## Related Issue
Closes #1410

## Type of Change
- [x] Bug fix

## Root Cause
`_build_case_summary_payload` returned a placeholder list for the `parties` field of every case summary response, ignoring the real case data.

## What Changed
- `api/routes/cases.py`: reads `parties` from `latest_doc.extracted_metadata` when a processed document is available, otherwise returns an empty list.

## Testing
- [ ] Cases with processed documents return real parties from `extracted_metadata`
- [ ] Cases with no documents return an empty parties list

## Checklist
- [x] No hardcoded secrets or credentials
- [x] Single focused change