### PR TITLE
fix(#1411): persist efiling tracking-ID ownership in DB to survive restarts and multi-worker deployments

### DIFF
--- a/api/routes/efiling.py
+++ b/api/routes/efiling.py
@@ -1,17 +1,16 @@
 from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel, field_validator
 from typing import Optional, Dict
-from threading import Lock
+from sqlalchemy.orm import Session
+
 from core.efiling import EfilingClient
 from api.auth import get_current_user, CurrentUser
+from database import get_db
+from db.models.efiling import UserFiling
 
 router = APIRouter(prefix="/api/efiling", tags=["efiling"])
 
 _MAX_BASE64_BYTES = 10 * 1024 * 1024  # 10 MB
-
-# Track ownership of tracking_ids per user (POC — replace with DB in production)
-_user_filings: Dict[str, set[str]] = {}
-_filings_lock = Lock()
 
 
 class SubmitRequest(BaseModel):
@@ -28,24 +27,38 @@ class SubmitRequest(BaseModel):
 
 
 @router.post("/submit")
-async def submit_document(req: SubmitRequest, current_user: CurrentUser = Depends(get_current_user)):
+async def submit_document(
+    req: SubmitRequest,
+    current_user: CurrentUser = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
     try:
         res = EfilingClient.submit(req.court, req.file_base64, metadata=req.metadata or {})
         tid = res.get("tracking_id")
         if tid:
-            with _filings_lock:
-                _user_filings.setdefault(str(current_user.user_id), set()).add(tid)
+            db.add(UserFiling(user_id=int(current_user.user_id), tracking_id=str(tid)))
+            db.commit()
         return res
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
 
 @router.get("/status/{tracking_id}")
-async def status(tracking_id: str, current_user: CurrentUser = Depends(get_current_user)):
-    uid = str(current_user.user_id)
-    with _filings_lock:
-        if tracking_id not in _user_filings.get(uid, set()):
-            raise HTTPException(status_code=404, detail="tracking id not found")
+async def status(
+    tracking_id: str,
+    current_user: CurrentUser = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    filing = (
+        db.query(UserFiling)
+        .filter(
+            UserFiling.user_id == int(current_user.user_id),
+            UserFiling.tracking_id == tracking_id,
+        )
+        .first()
+    )
+    if not filing:
+        raise HTTPException(status_code=404, detail="tracking id not found")
     try:
         res = EfilingClient.get_status(tracking_id)
         return res

--- a/db/models/efiling.py
+++ b/db/models/efiling.py
@@ -1,0 +1,34 @@
+"""SQLAlchemy model for persisting e-filing tracking-ID ownership.
+
+Replaces the previous in-process dict ``_user_filings`` in
+``api/routes/efiling.py``.  Storing filing ownership in the database
+ensures that status lookups survive server restarts and work correctly
+across multiple worker processes.
+"""
+
+import datetime as dt
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Index
+from db.base import Base
+
+
+class UserFiling(Base):
+    """Maps a user to a court e-filing tracking ID they submitted."""
+
+    __tablename__ = "user_filings"
+    __table_args__ = (
+        Index("ix_user_filings_user_id", "user_id"),
+        Index("ix_user_filings_tracking_id", "tracking_id"),
+    )
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    tracking_id = Column(String(255), nullable=False)
+    created_at = Column(
+        DateTime(timezone=True),
+        default=lambda: dt.datetime.now(dt.timezone.utc),
+        nullable=False,
+    )


### PR DESCRIPTION
## Summary
Replaces the in-process `_user_filings` dict with a `UserFiling` database table so that filing ownership persists across restarts and is consistent across all worker processes.

## Related Issue
Closes #1411

## Type of Change
- [x] Bug fix

## Root Cause
The efiling route tracked which `tracking_id` values belong to which user in a module-level `Dict[str, set[str]]`. Two production defects follow:
1. Every server restart wiped the dict.
2. Multi-worker deployments gave each worker its own copy, causing status lookups on a different worker to always return 404.

## What Changed
- `db/models/efiling.py`: new `UserFiling` model (`user_id`, `tracking_id`, `created_at`)
- `api/routes/efiling.py`: POST /submit inserts a `UserFiling` row; GET /status/{id} queries the table to verify ownership

## Testing
- [ ] Submit a filing then restart the server: status lookup still succeeds
- [ ] Submit on worker A, then query status on worker B: returns correctly
- [ ] A user cannot look up a tracking ID that belongs to another user

## Checklist
- [x] No hardcoded secrets or credentials
- [x] Single focused change