### PR TITLE
feat(api): Redis-based rate limiting for document processing endpoints

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -179,6 +179,28 @@ class Config:
         except Exception:
             return str(_get_val("SENDGRID_API_KEY", "") or "")
 
+    # --- Rate Limiting ---
+    RATE_LIMIT_ENABLED = _get_bool_env("RATE_LIMIT_ENABLED", False)
+    REDIS_URL = _get_val("REDIS_URL", "")
+    RATE_LIMIT_REQUESTS = _get_int_env("RATE_LIMIT_REQUESTS", 100)
+    RATE_LIMIT_WINDOW = _get_int_env("RATE_LIMIT_WINDOW", 60)
+    RATE_LIMIT_BURST = _get_int_env("RATE_LIMIT_BURST", 10)
+    RATE_LIMIT_ABUSE_THRESHOLD = _get_int_env("RATE_LIMIT_ABUSE_THRESHOLD", 3)
+    RATE_LIMIT_ABUSE_WINDOW = _get_int_env("RATE_LIMIT_ABUSE_WINDOW", 60)
+    RATE_LIMIT_ABUSE_BLOCK_SECONDS = _get_int_env("RATE_LIMIT_ABUSE_BLOCK_SECONDS", 300)
+    AUTH_RATE_LIMIT_REQUESTS = _get_int_env("AUTH_RATE_LIMIT_REQUESTS", 5)
+    AUTH_RATE_LIMIT_WINDOW = _get_int_env("AUTH_RATE_LIMIT_WINDOW", 60)
+    API_KEY_HEADER = _get_val("API_KEY_HEADER", "X-API-Key")
+
+    # --- CORS / API Server ---
+    CORS_ORIGINS = _get_val("CORS_ORIGINS", "http://localhost:8080")
+    API_TITLE = _get_val("API_TITLE", "LegalAssist API")
+    API_VERSION = _get_val("API_VERSION", "1.0.0")
+    API_HOST = _get_val("API_HOST", "0.0.0.0")
+    API_PORT = _get_int_env("API_PORT", 8000)
+    API_WORKERS = _get_int_env("API_WORKERS", 1)
+    ENABLE_WEBSOCKET = _get_bool_env("ENABLE_WEBSOCKET", False)
+
     # --- Application URLs ---
     BASE_URL = _get_val("BASE_URL", "https://legalassist.ai")
 

--- a/api/routes/documents.py
+++ b/api/routes/documents.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 from api.models import DocumentAnalysisRequest, DocumentAnalysisSummary, AnalysisJobResponse
 from api.auth import get_current_user, CurrentUser
 from api.dependencies import get_db_rls
+from api.limiter import RateLimit
 from db.models.cases import Attachment
 
 try:
@@ -90,7 +91,8 @@ def validate_file_path(file_path: str) -> str:
     "/document",
     response_model=AnalysisJobResponse,
     summary="Analyze document asynchronously",
-    description="Upload or provide document text for analysis. Returns immediately with job ID."
+    description="Upload or provide document text for analysis. Returns immediately with job ID.",
+    dependencies=[Depends(RateLimit(requests=10, window=300))],
 )
 async def analyze_document(
     request: DocumentAnalysisRequest,
@@ -263,7 +265,8 @@ async def cancel_analysis(
     "/upload",
     response_model=AnalysisJobResponse,
     summary="Upload document file for analysis",
-    description="Upload a PDF, Word, or text file for legal analysis."
+    description="Upload a PDF, Word, or text file for legal analysis.",
+    dependencies=[Depends(RateLimit(requests=5, window=300))],
 )
 async def upload_document_file(
     http_request: Request,


### PR DESCRIPTION
## Changes by file
- `api/config.py`: Added missing rate-limit and API server configuration values:
  - `RATE_LIMIT_ENABLED`, `REDIS_URL`
  - `RATE_LIMIT_REQUESTS`, `RATE_LIMIT_WINDOW`, `RATE_LIMIT_BURST`
  - `RATE_LIMIT_ABUSE_THRESHOLD`, `RATE_LIMIT_ABUSE_WINDOW`, `RATE_LIMIT_ABUSE_BLOCK_SECONDS`
  - `AUTH_RATE_LIMIT_REQUESTS`, `AUTH_RATE_LIMIT_WINDOW`
  - `API_KEY_HEADER`, `CORS_ORIGINS`, `API_TITLE`, `API_VERSION`, `API_HOST`, `API_PORT`, `API_WORKERS`, `ENABLE_WEBSOCKET`
- `api/routes/documents.py`: Added `RateLimit` dependency to:
  - `POST /api/v1/analyze/document` → 10 requests per 300 seconds
  - `POST /api/v1/analyze/upload` → 5 requests per 300 seconds

## Technical Notes
- No changes to `api/limiter.py` — the existing `RATE_LIMIT_RULES` already matched the desired limits
- The `RateLimit` dependency factory is used (not `slowapi`) to stay consistent with the existing custom token-bucket implementation
- Decorators are evaluated before the global middleware, so per-endpoint limits take precedence
- Abuse threshold (default 3 violations) triggers a 5-minute block via Redis
- Fail-closed: if Redis is unavailable, requests are denied (not unlimited)
- Whitelist (`127.0.0.1`, `localhost`, internal services) bypasses all limits

Closes #1470