### PR TITLE
fix(database): add support for extracted metadata fields in update_case_document (#1489)

### DIFF
--- a/database.py
+++ b/database.py
@@ -1137,6 +1137,9 @@ def update_case_document(
     document_content: Optional[str] = None,
     summary: Optional[str] = None,
     remedies: Optional[dict] = None,
+    extracted_metadata: Optional[dict] = None,
+    extraction_method: Optional[str] = None,
+    ocr_used: Optional[bool] = None,
 ) -> Optional[CaseDocument]:
     """Update case document"""
     doc = db.query(CaseDocument).filter(CaseDocument.id == document_id).first()
@@ -1147,6 +1150,12 @@ def update_case_document(
             doc.summary = summary
         if remedies is not None:
             doc.remedies = remedies
+        if extracted_metadata is not None:
+            doc.extracted_metadata = extracted_metadata
+        if extraction_method is not None:
+            doc.extraction_method = extraction_method
+        if ocr_used is not None:
+            doc.ocr_used = ocr_used
         try:
             db.commit()
             db.refresh(doc)


### PR DESCRIPTION
## Related Issue

Closes #1489

## Summary

This PR resolves the mismatch between the task layer and the database interface by extending `update_case_document()` to support additional keyword arguments used during document processing workflows.

## Changes Made

* Added support for `extracted_metadata`
* Added support for `extraction_method`
* Added support for `ocr_used`
* Updated assignment logic to persist these values when provided

## Impact

This ensures metadata generated during OCR and document extraction workflows is correctly persisted to the `CaseDocument` model and prevents task/database interface inconsistencies.

## Testing

* Verified successful update of document metadata fields
* Confirmed backward compatibility with existing update flows
* Confirmed no changes to existing API contracts
