### PR TITLE
precedent browser extension

### DIFF
--- a/browser-extension/content.js
+++ b/browser-extension/content.js
@@ -1,0 +1,23 @@
+// Simple regex to match standard legal citations (e.g. "Roe v. Wade", "Brown v. Board of Education", "347 U.S. 483")
+const citationRegex = /\b([A-Z][\w\s]+ v\. [A-Z][\w\s]+|\d+\s+U\.S\.\s+\d+)\b/g;
+
+function highlightPrecedents(node) {
+    if (node.nodeType === Node.TEXT_NODE) {
+        const text = node.nodeValue;
+        if (citationRegex.test(text)) {
+            const span = document.createElement('span');
+            span.innerHTML = text.replace(citationRegex, '<span class="legalassist-highlight" title="Legal Precedent Detected">$&</span>');
+            node.parentNode.replaceChild(span, node);
+        }
+    } else if (node.nodeType === Node.ELEMENT_NODE && node.nodeName !== 'SCRIPT' && node.nodeName !== 'STYLE' && !node.classList.contains('legalassist-highlight')) {
+        for (let i = 0; i < node.childNodes.length; i++) {
+            highlightPrecedents(node.childNodes[i]);
+        }
+    }
+}
+
+// Run the highlighter once the page loads
+window.addEventListener('load', () => {
+    highlightPrecedents(document.body);
+    console.log("Legalassist-AI: Precedents highlighted.");
+});

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": 3,
+  "name": "Legalassist-AI Precedent Highlighter",
+  "version": "1.0",
+  "description": "Automatically highlights legal precedents and case citations in web pages.",
+  "permissions": [
+    "activeTab",
+    "scripting"
+  ],
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "css": ["style.css"],
+      "js": ["content.js"]
+    }
+  ],
+  "action": {
+    "default_title": "Legalassist Precedent Highlighter"
+  }
+}

--- a/browser-extension/style.css
+++ b/browser-extension/style.css
@@ -1,0 +1,13 @@
+/* Styles for highlighted legal precedents */
+.legalassist-highlight {
+    background-color: #fef08a; /* Yellow highlight */
+    border-bottom: 2px solid #ca8a04;
+    cursor: help;
+    border-radius: 2px;
+    padding: 0 2px;
+    transition: background-color 0.2s ease;
+}
+
+.legalassist-highlight:hover {
+    background-color: #fde047;
+}


### PR DESCRIPTION
closes #2113. put together a quick browser extension to highlight legal precedents on webpages.