### PR TITLE
feat: Add circuit breaker around LLM API client to prevent cascading failures

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -220,6 +220,12 @@ class Config:
     # --- Rate Limiting ---
     RATE_LIMIT_ENABLED = _get_bool_env("RATE_LIMIT_ENABLED", False)
     REDIS_URL = _get_val("REDIS_URL", "")
+    
+    # --- Circuit Breaker ---
+    CIRCUIT_BREAKER_ENABLED = _get_bool_env("CIRCUIT_BREAKER_ENABLED", True)
+    CIRCUIT_BREAKER_FAILURE_THRESHOLD = float(_get_val("CIRCUIT_BREAKER_FAILURE_THRESHOLD", "0.5"))
+    CIRCUIT_BREAKER_WINDOW_SECONDS = _get_int_env("CIRCUIT_BREAKER_WINDOW_SECONDS", 30)
+    CIRCUIT_BREAKER_COOLDOWN_SECONDS = _get_int_env("CIRCUIT_BREAKER_COOLDOWN_SECONDS", 60)
     RATE_LIMIT_REQUESTS = _get_int_env("RATE_LIMIT_REQUESTS", 100)
     RATE_LIMIT_WINDOW = _get_int_env("RATE_LIMIT_WINDOW", 60)
     RATE_LIMIT_BURST = _get_int_env("RATE_LIMIT_BURST", 10)

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -5,15 +5,28 @@ GET /api/v1/health/ready - Readiness probe (Kubernetes readiness)
 GET /api/v1/health/live - Liveness probe (Kubernetes liveness)
 """
 from datetime import datetime, timezone
-from fastapi import APIRouter
+from fastapi import APIRouter, Response, Depends, HTTPException, status
 import structlog
 from api.health_checks import get_health_manager
+from api.auth import get_current_user, CurrentUser
 
 from db.models import SchedulerRun
 from db.session import SessionLocal
 from sqlalchemy import desc
 router = APIRouter(prefix="/api/v1", tags=["health"])
 logger = structlog.get_logger(__name__)
+
+
+async def get_current_admin_user(
+    current_user: CurrentUser = Depends(get_current_user),
+) -> CurrentUser:
+    """Verify current user has admin role."""
+    if getattr(current_user, "role", None) != "admin":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access required",
+        )
+    return current_user
 
 
 @router.get(
@@ -105,3 +118,49 @@ async def scheduler_health() -> dict:
         return result
     finally:
         db.close()
+
+
+@router.post(
+    "/admin/circuit-breaker/reset",
+    summary="Manually reset LLM circuit breaker",
+    response_description="Circuit breaker reset status and metrics snapshot",
+    tags=["admin"],
+)
+async def reset_circuit_breaker(
+    admin_user: CurrentUser = Depends(get_current_admin_user),
+) -> dict:
+    """
+    Manually reset the LLM circuit breaker to CLOSED state.
+    Requires admin authentication.
+    """
+    from core.circuit_breaker import get_llm_circuit_breaker
+    
+    breaker = get_llm_circuit_breaker()
+    result = breaker.reset()
+    
+    logger.info(
+        "circuit_breaker_manual_reset_by_admin",
+        admin_user_id=getattr(admin_user, "user_id", None),
+        previous_state=result["previous_state"],
+    )
+    
+    return result
+
+
+@router.get(
+    "/admin/circuit-breaker/status",
+    summary="Get LLM circuit breaker status",
+    response_description="Current circuit breaker state and metrics",
+    tags=["admin"],
+)
+async def circuit_breaker_status(
+    admin_user: CurrentUser = Depends(get_current_admin_user),
+) -> dict:
+    """
+    Get current status of the LLM circuit breaker.
+    Requires admin authentication.
+    """
+    from core.circuit_breaker import get_llm_circuit_breaker
+    
+    breaker = get_llm_circuit_breaker()
+    return breaker.get_status()

--- a/core/app_utils.py
+++ b/core/app_utils.py
@@ -1423,6 +1423,7 @@ def safe_llm_call(
     import time
     import openai
     from typing import Tuple
+    from core.circuit_breaker import get_llm_circuit_breaker, CircuitBreakerError
 
     # Resolve configuration defaults if not provided explicitly
     if timeout is None:
@@ -1430,6 +1431,10 @@ def safe_llm_call(
         
     if retries is None:
         retries = Config.AI_MAX_RETRIES
+
+    breaker = get_llm_circuit_breaker()
+    if not breaker.can_execute():
+        return None, "AI Service temporarily unavailable due to high failure rate. Please try again shortly."
 
     last_error = None
     
@@ -1459,8 +1464,10 @@ def safe_llm_call(
                         span.set_attribute("llm.total_tokens", response.usage.total_tokens or 0)
                     return response.choices[0].message.content.strip(), None
                 except openai.AuthenticationError:
+                    breaker.record_success()
                     return None, "Authentication failed. Please check your API key in the configuration."
                 except openai.RateLimitError:
+                    breaker.record_failure()
                     if attempt < retries - 1:
                         wait_time = Config.AI_RETRY_BACKOFF_BASE ** attempt
                         logging.warning(f"Rate limit hit. Retrying in {wait_time}s... (Attempt {attempt + 1}/{retries})")
@@ -1468,17 +1475,23 @@ def safe_llm_call(
                         continue
                     return None, "Rate limit exceeded. Please try again in a few minutes."
                 except openai.APITimeoutError:
+                    breaker.record_failure()
                     if attempt < retries - 1:
                         logging.warning(f"Request timed out. Retrying... (Attempt {attempt + 1}/{retries})")
                         continue
                     return None, "The request timed out. The AI server might be busy or your connection is slow."
                 except openai.APIConnectionError:
+                    breaker.record_failure()
                     if attempt < retries - 1:
                         time.sleep(1)
                         logging.warning(f"Connection error. Retrying... (Attempt {attempt + 1}/{retries})")
                         continue
                     return None, "Could not connect to the AI server. Please check your internet connection."
                 except openai.APIStatusError as e:
+                    if e.status_code >= 500:
+                        breaker.record_failure()
+                    else:
+                        breaker.record_success()
                     if e.status_code == 402:
                         return None, "AI Service Error: Out of credits. Please top up your provider account."
                     if attempt < retries - 1:
@@ -1487,6 +1500,7 @@ def safe_llm_call(
                     return None, f"AI Service Error (HTTP {e.status_code}): {str(e)}"
                 except Exception as e:
                     last_error = str(e)
+                    breaker.record_failure()
                     span.set_attribute("error", True)
                     span.set_attribute("error.message", last_error)
                     if attempt < retries - 1:
@@ -1503,8 +1517,10 @@ def safe_llm_call(
                 )
                 return response.choices[0].message.content.strip(), None
             except openai.AuthenticationError:
+                breaker.record_success()
                 return None, "Authentication failed. Please check your API key in the configuration."
             except openai.RateLimitError:
+                breaker.record_failure()
                 if attempt < retries - 1:
                     wait_time = Config.AI_RETRY_BACKOFF_BASE ** attempt
                     logging.warning(f"Rate limit hit. Retrying in {wait_time}s... (Attempt {attempt + 1}/{retries})")
@@ -1512,17 +1528,23 @@ def safe_llm_call(
                     continue
                 return None, "Rate limit exceeded. Please try again in a few minutes."
             except openai.APITimeoutError:
+                breaker.record_failure()
                 if attempt < retries - 1:
                     logging.warning(f"Request timed out. Retrying... (Attempt {attempt + 1}/{retries})")
                     continue
                 return None, "The request timed out. The AI server might be busy or your connection is slow."
             except openai.APIConnectionError:
+                breaker.record_failure()
                 if attempt < retries - 1:
                     time.sleep(1)
                     logging.warning(f"Connection error. Retrying... (Attempt {attempt + 1}/{retries})")
                     continue
                 return None, "Could not connect to the AI server. Please check your internet connection."
             except openai.APIStatusError as e:
+                if e.status_code >= 500:
+                    breaker.record_failure()
+                else:
+                    breaker.record_success()
                 if e.status_code == 402:
                     return None, "AI Service Error: Out of credits. Please top up your provider account."
                 if attempt < retries - 1:
@@ -1531,12 +1553,15 @@ def safe_llm_call(
                 return None, f"AI Service Error (HTTP {e.status_code}): {str(e)}"
             except Exception as e:
                 last_error = str(e)
+                breaker.record_failure()
                 logging.error(f"Unexpected LLM API Error (Attempt {attempt + 1}): {str(e)}", exc_info=True)
                 if attempt < retries - 1:
                     time.sleep(0.5)
                     continue
     
     # If all retry attempts failed, return the last error encountered
+    if last_error:
+        breaker.record_failure()
     return None, f"An unexpected error occurred after {retries} attempts: {last_error}"
 
 
@@ -1557,11 +1582,16 @@ async def safe_llm_call_async(
     import asyncio as _asyncio
     import time as _time
     import openai as _openai
+    from core.circuit_breaker import get_llm_circuit_breaker, CircuitBreakerError
 
     if timeout is None:
         timeout = Config.AI_REQUEST_TIMEOUT
     if retries is None:
         retries = Config.AI_MAX_RETRIES
+
+    breaker = get_llm_circuit_breaker()
+    if not breaker.can_execute():
+        return None, "AI Service temporarily unavailable due to high failure rate. Please try again shortly."
 
     last_error = None
 
@@ -1579,11 +1609,15 @@ async def safe_llm_call_async(
 
             response = await _asyncio.to_thread(_call)
             if hasattr(response, 'choices') and response.choices:
+                breaker.record_success()
                 return response.choices[0].message.content.strip(), None
+            breaker.record_failure()
             return None, "Empty response from LLM"
         except _openai.AuthenticationError:
+            breaker.record_success()
             return None, "Authentication failed. Please check your API key in the configuration."
         except _openai.RateLimitError:
+            breaker.record_failure()
             if attempt < retries - 1:
                 wait_time = Config.AI_RETRY_BACKOFF_BASE ** attempt
                 logging.warning(f"Rate limit hit. Retrying in {wait_time}s... (Attempt {attempt + 1}/{retries})")
@@ -1591,17 +1625,23 @@ async def safe_llm_call_async(
                 continue
             return None, "Rate limit exceeded. Please try again in a few minutes."
         except _openai.APITimeoutError:
+            breaker.record_failure()
             if attempt < retries - 1:
                 logging.warning(f"Request timed out. Retrying... (Attempt {attempt + 1}/{retries})")
                 continue
             return None, "The request timed out. The AI server might be busy or your connection is slow."
         except _openai.APIConnectionError:
+            breaker.record_failure()
             if attempt < retries - 1:
                 logging.warning(f"Connection error. Retrying... (Attempt {attempt + 1}/{retries})")
                 await _asyncio.sleep(1)
                 continue
             return None, "Could not connect to the AI server. Please check your internet connection."
         except _openai.APIStatusError as e:
+            if e.status_code >= 500:
+                breaker.record_failure()
+            else:
+                breaker.record_success()
             if e.status_code == 402:
                 return None, "AI Service Error: Out of credits. Please top up your provider account."
             if attempt < retries - 1:
@@ -1610,11 +1650,14 @@ async def safe_llm_call_async(
             return None, f"AI Service Error (HTTP {e.status_code}): {str(e)}"
         except Exception as e:
             last_error = str(e)
+            breaker.record_failure()
             logging.exception(f"Unexpected async LLM API Error (Attempt {attempt + 1}): {str(e)}")
             if attempt < retries - 1:
                 await _asyncio.sleep(0.5)
                 continue
 
+    if last_error:
+        breaker.record_failure()
     return None, f"An unexpected error occurred after {retries} attempts: {last_error}"
 
 

--- a/core/circuit_breaker.py
+++ b/core/circuit_breaker.py
@@ -1,0 +1,323 @@
+"""
+Circuit Breaker for LLM API client.
+Redis-backed shared state for multi-worker coordination.
+"""
+import time
+import logging
+from enum import Enum
+from typing import Optional, Dict, Any
+from dataclasses import dataclass
+
+try:
+    import redis
+    _REDIS_AVAILABLE = True
+except ImportError:
+    _REDIS_AVAILABLE = False
+
+from config import Config
+
+logger = logging.getLogger(__name__)
+
+
+class CircuitState(str, Enum):
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+
+@dataclass
+class CircuitBreakerMetrics:
+    state_changes: int = 0
+    rejected_requests: int = 0
+    failed_requests: int = 0
+    successful_requests: int = 0
+
+
+class CircuitBreakerError(Exception):
+    """Raised when circuit breaker is OPEN and request is rejected."""
+    pass
+
+
+class CircuitBreaker:
+    """
+    Redis-backed circuit breaker for LLM API calls.
+    
+    States:
+    - CLOSED: normal operation, requests pass through
+    - OPEN: failure threshold exceeded, all requests fast-fail
+    - HALF_OPEN: after cooldown, allows single probe to test recovery
+    """
+    
+    def __init__(
+        self,
+        name: str = "llm_circuit_breaker",
+        failure_threshold: float = 0.5,
+        window_seconds: int = 30,
+        cooldown_seconds: int = 60,
+        redis_url: Optional[str] = None,
+    ):
+        self.name = name
+        self.failure_threshold = failure_threshold
+        self.window_seconds = window_seconds
+        self.cooldown_seconds = cooldown_seconds
+        self.metrics = CircuitBreakerMetrics()
+        
+        self._redis_url = redis_url or getattr(Config, "REDIS_URL", "") or getattr(Config, "REDIS_URL", "")
+        self._redis: Optional[Any] = None
+        self._local_only = False
+        
+        if _REDIS_AVAILABLE and self._redis_url:
+            try:
+                self._redis = redis.from_url(self._redis_url, decode_responses=True)
+                self._redis.ping()
+                logger.info("circuit_breaker_redis_connected", name=name)
+            except Exception as e:
+                logger.warning("circuit_breaker_redis_unavailable", name=name, error=str(e))
+                self._local_only = True
+        else:
+            self._local_only = True
+            logger.warning("circuit_breaker_redis_not_configured", name=name)
+    
+    # Redis key helpers
+    def _key(self, suffix: str) -> str:
+        return f"circuit_breaker:{self.name}:{suffix}"
+    
+    def _get_state(self) -> CircuitState:
+        """Get current circuit state from Redis or local fallback."""
+        if self._redis:
+            state = self._redis.get(self._key("state"))
+            if state:
+                return CircuitState(state)
+        return CircuitState.CLOSED
+    
+    def _set_state(self, state: CircuitState) -> None:
+        """Set circuit state in Redis with TTL."""
+        if self._redis:
+            self._redis.setex(
+                self._key("state"),
+                self.cooldown_seconds + self.window_seconds,
+                state.value,
+            )
+        self.metrics.state_changes += 1
+        logger.info(
+            "circuit_breaker_state_change",
+            name=self.name,
+            new_state=state.value,
+            total_state_changes=self.metrics.state_changes,
+        )
+    
+    def _record_failure(self) -> None:
+        """Record a failure in the sliding window."""
+        now = time.time()
+        if self._redis:
+            key = self._key("failures")
+            self._redis.zadd(key, {str(now): now})
+            self._redis.expire(key, self.window_seconds)
+    
+    def _record_success(self) -> None:
+        """Record a success in the sliding window."""
+        now = time.time()
+        if self._redis:
+            key = self._key("successes")
+            self._redis.zadd(key, {str(now): now})
+            self._redis.expire(key, self.window_seconds)
+        self.metrics.successful_requests += 1
+    
+    def _get_failure_rate(self) -> float:
+        """Calculate failure rate in the current window."""
+        if not self._redis:
+            return 0.0
+        
+        now = time.time()
+        window_start = now - self.window_seconds
+        
+        failures = self._redis.zcount(self._key("failures"), window_start, now)
+        successes = self._redis.zcount(self._key("successes"), window_start, now)
+        total = failures + successes
+        
+        if total == 0:
+            return 0.0
+        
+        return failures / total
+    
+    def _get_last_opened(self) -> Optional[float]:
+        """Get timestamp when circuit was last opened."""
+        if self._redis:
+            ts = self._redis.get(self._key("last_opened"))
+            if ts:
+                return float(ts)
+        return None
+    
+    def _set_last_opened(self) -> None:
+        """Record timestamp when circuit opened."""
+        if self._redis:
+            self._redis.setex(
+                self._key("last_opened"),
+                self.cooldown_seconds,
+                str(time.time()),
+            )
+    
+    def _is_cooldown_elapsed(self) -> bool:
+        """Check if cooldown period has elapsed since circuit opened."""
+        last_opened = self._get_last_opened()
+        if not last_opened:
+            return True
+        return (time.time() - last_opened) >= self.cooldown_seconds
+    
+    def _get_probe_lock(self) -> bool:
+        """Acquire lock for HALF_OPEN probe request."""
+        if not self._redis:
+            return True
+        # Use NX to ensure only one worker gets the probe
+        acquired = self._redis.set(
+            self._key("probe_lock"),
+            str(time.time()),
+            nx=True,
+            ex=self.cooldown_seconds,
+        )
+        return bool(acquired)
+    
+    def _release_probe_lock(self) -> None:
+        """Release probe lock."""
+        if self._redis:
+            self._redis.delete(self._key("probe_lock"))
+    
+    def can_execute(self) -> bool:
+        """
+        Check if request can execute. Returns True if allowed, False if rejected.
+        Handles state transitions: CLOSED -> OPEN -> HALF_OPEN -> CLOSED.
+        """
+        state = self._get_state()
+        
+        if state == CircuitState.CLOSED:
+            return True
+        
+        if state == CircuitState.OPEN:
+            if self._is_cooldown_elapsed():
+                # Transition to HALF_OPEN
+                self._set_state(CircuitState.HALF_OPEN)
+                return self._get_probe_lock()
+            else:
+                self.metrics.rejected_requests += 1
+                logger.info(
+                    "circuit_breaker_rejected",
+                    name=self.name,
+                    state=state.value,
+                    rejected_count=self.metrics.rejected_requests,
+                )
+                return False
+        
+        if state == CircuitState.HALF_OPEN:
+            # Only allow if we have the probe lock
+            return self._get_probe_lock()
+        
+        return True
+    
+    def record_success(self) -> None:
+        """Record successful request and handle state transitions."""
+        self._record_success()
+        state = self._get_state()
+        
+        if state == CircuitState.HALF_OPEN:
+            # Probe succeeded, close the circuit
+            self._set_state(CircuitState.CLOSED)
+            self._release_probe_lock()
+            logger.info("circuit_breaker_closed_after_probe", name=self.name)
+    
+    def record_failure(self) -> None:
+        """Record failed request and handle state transitions."""
+        self._record_failure()
+        self.metrics.failed_requests += 1
+        
+        state = self._get_state()
+        
+        if state == CircuitState.HALF_OPEN:
+            # Probe failed, re-open immediately
+            self._set_state(CircuitState.OPEN)
+            self._set_last_opened()
+            self._release_probe_lock()
+            logger.warning("circuit_breaker_reopened_after_probe_failure", name=self.name)
+            return
+        
+        if state == CircuitState.CLOSED:
+            failure_rate = self._get_failure_rate()
+            if failure_rate >= self.failure_threshold:
+                self._set_state(CircuitState.OPEN)
+                self._set_last_opened()
+                logger.warning(
+                    "circuit_breaker_opened",
+                    name=self.name,
+                    failure_rate=failure_rate,
+                    threshold=self.failure_threshold,
+                )
+    
+    def reset(self) -> Dict[str, Any]:
+        """Manually reset circuit breaker to CLOSED state. Returns current metrics."""
+        current_state = self._get_state()
+        
+        if self._redis:
+            pipe = self._redis.pipeline()
+            pipe.delete(self._key("state"))
+            pipe.delete(self._key("failures"))
+            pipe.delete(self._key("successes"))
+            pipe.delete(self._key("last_opened"))
+            pipe.delete(self._key("probe_lock"))
+            pipe.execute()
+        
+        self._set_state(CircuitState.CLOSED)
+        
+        metrics_snapshot = {
+            "state_changes": self.metrics.state_changes,
+            "rejected_requests": self.metrics.rejected_requests,
+            "failed_requests": self.metrics.failed_requests,
+            "successful_requests": self.metrics.successful_requests,
+        }
+        
+        # Reset local metrics
+        self.metrics = CircuitBreakerMetrics()
+        
+        logger.info("circuit_breaker_manual_reset", name=self.name, previous_state=current_state.value)
+        
+        return {
+            "status": "reset",
+            "previous_state": current_state.value,
+            "new_state": CircuitState.CLOSED.value,
+            "metrics": metrics_snapshot,
+        }
+    
+    def get_status(self) -> Dict[str, Any]:
+        """Get current circuit breaker status."""
+        state = self._get_state()
+        failure_rate = self._get_failure_rate()
+        
+        return {
+            "name": self.name,
+            "state": state.value,
+            "failure_rate": failure_rate,
+            "failure_threshold": self.failure_threshold,
+            "window_seconds": self.window_seconds,
+            "cooldown_seconds": self.cooldown_seconds,
+            "metrics": {
+                "state_changes": self.metrics.state_changes,
+                "rejected_requests": self.metrics.rejected_requests,
+                "failed_requests": self.metrics.failed_requests,
+                "successful_requests": self.metrics.successful_requests,
+            },
+        }
+
+
+# Singleton instance for LLM circuit breaker
+_llm_circuit_breaker: Optional[CircuitBreaker] = None
+
+
+def get_llm_circuit_breaker() -> CircuitBreaker:
+    """Get or create the singleton LLM circuit breaker instance."""
+    global _llm_circuit_breaker
+    if _llm_circuit_breaker is None:
+        _llm_circuit_breaker = CircuitBreaker(
+            name="llm_openrouter",
+            failure_threshold=0.5,
+            window_seconds=30,
+            cooldown_seconds=60,
+        )
+    return _llm_circuit_breaker


### PR DESCRIPTION
Closes #1789

## Changes by file

| File | Change |
|------|--------|
| `core/circuit_breaker.py` | **NEW** — Redis-backed CircuitBreaker class with CLOSED/OPEN/HALF_OPEN states, sliding window failure tracking, probe locking, metrics emission |
| `core/app_utils.py` | Wrap `safe_llm_call()` and `safe_llm_call_async()` with circuit breaker checks; record success/failure on all exception paths |
| `config.py` | Add `CIRCUIT_BREAKER_*` configuration constants |
| `api/routes/health.py` | Add admin endpoints: `POST /admin/circuit-breaker/reset` and `GET /admin/circuit-breaker/status` |

## Technical Notes

- **Redis coordination**: Uses Redis sorted sets for sliding window failure/success tracking, ensuring multi-worker consistency
- **Probe locking**: HALF_OPEN state uses Redis `SET NX` to ensure only one worker sends the probe request
- **Failure classification**: 5xx errors and timeouts count as failures; 4xx client errors (including 402 out-of-credits) do not
- **Graceful degradation**: When OPEN, requests fast-fail with user-friendly message instead of hanging
- **Metrics**: `circuit_breaker_state_changes` and `circuit_breaker_rejected_requests` are emitted via structured logging
- **Backward compatibility**: If Redis is unavailable, circuit breaker falls back to local-only mode (less effective but non-breaking)