### PR TITLE
fix: resolve missing imports in notifications crud module (#2211)

### DIFF
--- a/db/crud/notifications.py
+++ b/db/crud/notifications.py
@@ -1,4 +1,4 @@
-﻿import logging
+import logging
 import datetime as dt
 from typing import Optional, List, Iterable
 from sqlalchemy.orm import Session

--- a/db/crud/notifications.py
+++ b/db/crud/notifications.py
@@ -1,4 +1,4 @@
-from cmath import log
+﻿import logging
 import datetime as dt
 from typing import Optional, List, Iterable
 from sqlalchemy.orm import Session


### PR DESCRIPTION
## Summary
Resolves #2211 by fixing an incorrect import in `db/crud/notifications.py`.

## Problem
The file had `from cmath import log` on line 1, which was incorrect because:
- `log` is **never used as a math function** in this file
- The name `log` is used throughout the file as a **local variable** for `NotificationLog` objects
- The import was shadowing the local variable name and polluting the namespace

## Changes
<img width="877" height="472" alt="Screenshot 2026-06-12 132708" src="https://github.com/user-attachments/assets/913701b5-408a-49d8-aba5-96678e05c3cc" />
